### PR TITLE
[Feat] 내 주문 목록 조회 api 추가

### DIFF
--- a/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
@@ -9,7 +9,9 @@ public enum ErrorCode {
 
 	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
 	ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문을 찾을 수 없습니다."),
-	ORDER_INVALID_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다.");
+	RESTAURANT_NOT_FOUND(HttpStatus.NOT_FOUND, "음식점을 찾을 수 없습니다."),
+	ORDER_INVALID_STATUS(HttpStatus.BAD_REQUEST, "주문 상태가 올바르지 않습니다."),
+	USER_ACCESS_DENIED(HttpStatus.FORBIDDEN, "사용자의 접근 권한이 존재하지 않습니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public enum SuccessCode {
-	ORDER_CREATE_SUCCESS(HttpStatus.OK, "주문 생성 성공입니다.");
+	ORDER_CREATE_SUCCESS(HttpStatus.OK, "주문 생성 성공입니다."),
+	ORDER_GET_SUCCESS(HttpStatus.OK, "주문 목록 조회 성공입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/common/exception/OrderException.java
+++ b/src/main/java/com/order/orderlink/common/exception/OrderException.java
@@ -1,0 +1,9 @@
+package com.order.orderlink.common.exception;
+
+import com.order.orderlink.common.enums.ErrorCode;
+
+public class OrderException extends BaseException {
+	public OrderException(ErrorCode errorCode) {
+		super(errorCode.getStatus(), errorCode.getMessage());
+	}
+}

--- a/src/main/java/com/order/orderlink/common/exception/RestaurantException.java
+++ b/src/main/java/com/order/orderlink/common/exception/RestaurantException.java
@@ -1,0 +1,9 @@
+package com.order.orderlink.common.exception;
+
+import com.order.orderlink.common.enums.ErrorCode;
+
+public class RestaurantException extends BaseException {
+	public RestaurantException(ErrorCode errorCode) {
+		super(errorCode.getStatus(), errorCode.getMessage());
+	}
+}

--- a/src/main/java/com/order/orderlink/order/application/OrderService.java
+++ b/src/main/java/com/order/orderlink/order/application/OrderService.java
@@ -1,19 +1,31 @@
 package com.order.orderlink.order.application;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.order.orderlink.common.auth.UserDetailsImpl;
+import com.order.orderlink.common.enums.ErrorCode;
+import com.order.orderlink.common.exception.AuthException;
+import com.order.orderlink.common.exception.RestaurantException;
+import com.order.orderlink.order.application.dtos.OrderDTO;
+import com.order.orderlink.order.application.dtos.OrderFoodDTO;
 import com.order.orderlink.order.application.dtos.OrderRequest;
 import com.order.orderlink.order.application.dtos.OrderResponse;
 import com.order.orderlink.order.domain.Order;
 import com.order.orderlink.order.domain.OrderStatus;
 import com.order.orderlink.order.domain.repository.OrderRepository;
 import com.order.orderlink.orderitem.domain.OrderItem;
+import com.order.orderlink.restaurant.domain.Restaurant;
+import com.order.orderlink.restaurant.domain.repository.RestaurantRepository;
+import com.order.orderlink.user.domain.UserRoleEnum;
 
-import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -22,9 +34,10 @@ import lombok.RequiredArgsConstructor;
 public class OrderService {
 
 	private final OrderRepository orderRepository;
-	private final EntityManager entityManager; // Flush를 위해 추가
+	private final RestaurantRepository restaurantRepository;
 
-	public OrderResponse.Create createOrder(UUID userId, OrderRequest.Create request) {
+	public OrderResponse.Create createOrder(UserDetailsImpl userDetails, OrderRequest.Create request) {
+		UUID userId = getUserId(userDetails);
 		Order order = Order.builder()
 			.userId(userId)
 			.restaurantId(request.getRestaurantId())
@@ -48,6 +61,50 @@ public class OrderService {
 		orderRepository.save(order);
 
 		return new OrderResponse.Create(order.getId());
+	}
+
+	private static UUID getUserId(UserDetailsImpl userDetails) {
+		UUID userId = userDetails.getUser().getId();
+		return userId;
+	}
+
+	@Transactional(readOnly = true)
+	public OrderResponse.GetOrders getMyOrders(UserDetailsImpl userDetails, int page, int size) {
+		UUID userId = validateRoleAndGetUserId(userDetails, UserRoleEnum.CUSTOMER);
+
+		Pageable pageable = PageRequest.of(page - 1, size);
+		Page<Order> ordersPage = orderRepository.findAllByUserId(userId, pageable);
+
+		List<OrderDTO> orders = new ArrayList<>();
+		for (Order order : ordersPage.getContent()) {
+			List<OrderFoodDTO> foods = new ArrayList<>();
+			for (OrderItem food : order.getOrderItems()) {
+				foods.add(new OrderFoodDTO(food.getFoodName(), food.getPrice(), food.getQuantity()));
+			}
+			Restaurant restaurant = restaurantRepository.findById(order.getRestaurantId())
+				.orElseThrow(() -> new RestaurantException(ErrorCode.RESTAURANT_NOT_FOUND));
+
+			orders.add(OrderDTO.builder()
+				.orderId(order.getId())
+				.restaurantName(restaurant.getName())
+				.foods(foods)
+				.totalPrice(order.getTotalPrice())
+				.deliveryAddress(order.getDeliveryAddress())
+				.build());
+		}
+		return OrderResponse.GetOrders.builder()
+			.orders(orders)
+			.totalPages(ordersPage.getTotalPages())
+			.currentPage(page)
+			.build();
+	}
+
+	private static UUID validateRoleAndGetUserId(UserDetailsImpl userDetails, UserRoleEnum role) {
+		if (!userDetails.getUser().getRole().equals(role)) {
+			throw new AuthException(ErrorCode.USER_ACCESS_DENIED);
+		}
+		UUID userId = getUserId(userDetails);
+		return userId;
 	}
 }
 

--- a/src/main/java/com/order/orderlink/order/application/dtos/OrderDTO.java
+++ b/src/main/java/com/order/orderlink/order/application/dtos/OrderDTO.java
@@ -1,0 +1,21 @@
+package com.order.orderlink.order.application.dtos;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OrderDTO {
+	private UUID orderId;
+	private String restaurantName;
+	private int totalPrice;
+	private String deliveryAddress;
+	private List<OrderFoodDTO> foods;
+}

--- a/src/main/java/com/order/orderlink/order/application/dtos/OrderFoodDTO.java
+++ b/src/main/java/com/order/orderlink/order/application/dtos/OrderFoodDTO.java
@@ -9,6 +9,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class OrderFoodDTO {
 	private String foodName;
-	private Integer price;
-	private Integer count;
+	private int price;
+	private int count;
 }

--- a/src/main/java/com/order/orderlink/order/application/dtos/OrderRequest.java
+++ b/src/main/java/com/order/orderlink/order/application/dtos/OrderRequest.java
@@ -19,7 +19,7 @@ public class OrderRequest {
 		private List<OrderFoodDTO> foods;
 
 		@NotNull
-		private Integer totalPrice;
+		private int totalPrice;
 
 		private String deliveryAddress;
 		private String deliveryRequest;

--- a/src/main/java/com/order/orderlink/order/application/dtos/OrderResponse.java
+++ b/src/main/java/com/order/orderlink/order/application/dtos/OrderResponse.java
@@ -1,5 +1,6 @@
 package com.order.orderlink.order.application.dtos;
 
+import java.util.List;
 import java.util.UUID;
 
 import lombok.AllArgsConstructor;
@@ -19,4 +20,12 @@ public class OrderResponse {
 		private final UUID orderId;
 	}
 
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class GetOrders {
+		private final List<OrderDTO> orders;
+		private final int totalPages;
+		private final int currentPage;
+	}
 }

--- a/src/main/java/com/order/orderlink/order/domain/repository/OrderRepository.java
+++ b/src/main/java/com/order/orderlink/order/domain/repository/OrderRepository.java
@@ -2,9 +2,13 @@ package com.order.orderlink.order.domain.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.order.orderlink.order.domain.Order;
 
 public interface OrderRepository extends JpaRepository<Order, UUID> {
+
+	Page<Order> findAllByUserId(UUID userId, Pageable pageable);
 }

--- a/src/main/java/com/order/orderlink/order/presentation/OrderController.java
+++ b/src/main/java/com/order/orderlink/order/presentation/OrderController.java
@@ -1,7 +1,5 @@
 package com.order.orderlink.order.presentation;
 
-import java.util.UUID;
-
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -9,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.order.orderlink.common.auth.UserDetailsImpl;
@@ -27,9 +26,14 @@ public class OrderController {
 
 	private final OrderService orderService;
 
-	@GetMapping
-	public ResponseEntity<?> getOrders() {
-		return ResponseEntity.ok("getOrders() has been called!");
+	@GetMapping("/my")
+	public SuccessResponse<OrderResponse.GetOrders> getMyOrders(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@RequestParam int page,
+		@RequestParam int size
+	) {
+		return SuccessResponse.success(SuccessCode.ORDER_GET_SUCCESS,
+			orderService.getMyOrders(userDetails, page, size));
 	}
 
 	@GetMapping("/{id}")
@@ -41,7 +45,7 @@ public class OrderController {
 	public SuccessResponse<OrderResponse.Create> createOrder(
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestBody OrderRequest.Create request) {
-		UUID userId = userDetails.getUser().getId();
-		return SuccessResponse.success(SuccessCode.ORDER_CREATE_SUCCESS, orderService.createOrder(userId, request));
+		return SuccessResponse.success(SuccessCode.ORDER_CREATE_SUCCESS,
+			orderService.createOrder(userDetails, request));
 	}
 }

--- a/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
@@ -1,12 +1,32 @@
 package com.order.orderlink.restaurant.domain;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.Id;
+import java.util.UUID;
 
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 @Entity
+@Table(name = "p_restaurants")
+@EntityListeners(AuditingEntityListener.class)
 public class Restaurant {
 
 	@Id
-	private Long id;
-	
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	private UUID id;
+
+	private String name;
+
 }

--- a/src/main/java/com/order/orderlink/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/repository/RestaurantRepository.java
@@ -1,9 +1,11 @@
 package com.order.orderlink.restaurant.domain.repository;
 
+import java.util.UUID;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.order.orderlink.restaurant.domain.Restaurant;
 
-public interface RestaurantRepository extends JpaRepository<Restaurant, Long> {
-	
+public interface RestaurantRepository extends JpaRepository<Restaurant, UUID> {
+
 }


### PR DESCRIPTION
- Integer 로 되어있는 price, count 등을 null 비허용이 나을 것 같아서 Integer-> int 로 바꾸었습니다
- userId, user role 추출하는 게 중복될 것 같아서 따로 분리했습니다. 
- 주문 목록과 주문 아이템을 페이징해서 가져옵니다. 페이징은 이때 1-based index로 설정했습니다. 
```
{
    "code": 200,
    "message": "주문 목록 조회 성공입니다.",
    "data": {
        "orders": [
            {
                "orderId": "7a94cbbc-1bbe-4de2-aa9c-02742d2ce96d",
                "restaurantName": "꼰미고",
                "totalPrice": 25000,
                "deliveryAddress": "서울 강남구 테헤란로 123",
                "foods": [
                    {
                        "foodName": "마라탕",
                        "price": 1000,
                        "count": 2
                    },
                    {
                        "foodName": "마라탕",
                        "price": 1000,
                        "count": 2
                    }
                ]
            },
            {
                "orderId": "f24eec9d-9893-4963-80c3-7231a294a8ad",
                "restaurantName": "꼰미고",
                "totalPrice": 25000,
                "deliveryAddress": "서울 강남구 테헤란로 123",
                "foods": [
                    {
                        "foodName": "마라탕",
                        "price": 1000,
                        "count": 2
                    },
                    {
                        "foodName": "마라탕",
                        "price": 1000,
                        "count": 2
                    }
                ]
            }
        ],
        "totalPages": 1,
        "currentPage": 1
    }
}
```