### PR TITLE
[Feat] 주문 상세 조회 기능 추가

### DIFF
--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -12,7 +12,8 @@ public enum SuccessCode {
 	USER_CREATE_SUCCESS(HttpStatus.OK, "회원가입 성공입니다."),
 	LOGIN_SUCCESS(HttpStatus.OK, "로그인 성공입니다."),
 	ORDER_CREATE_SUCCESS(HttpStatus.OK, "주문 생성 성공입니다."),
-	ORDER_GET_SUCCESS(HttpStatus.OK, "주문 목록 조회 성공입니다.");
+	ORDER_GET_SUCCESS(HttpStatus.OK, "주문 목록 조회 성공입니다."),
+	ORDER_GET_DETAIL_SUCCESS(HttpStatus.OK, "주문 상세 조회 성공입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/order/application/dtos/OrderResponse.java
+++ b/src/main/java/com/order/orderlink/order/application/dtos/OrderResponse.java
@@ -1,7 +1,11 @@
 package com.order.orderlink.order.application.dtos;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
+
+import com.order.orderlink.order.domain.OrderStatus;
+import com.order.orderlink.payment.domain.PaymentStatus;
 
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -28,4 +32,22 @@ public class OrderResponse {
 		private final int totalPages;
 		private final int currentPage;
 	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class GetOrderDetail {
+		private final UUID orderId;
+		private final String restaurantName;
+		private final int totalPrice;
+		private final String deliveryAddress;
+		private final List<OrderFoodDTO> foods;
+		private final OrderStatus status;
+		private final LocalDateTime createdAt;
+		private final int paymentPrice;
+		private final String paymentBank;
+		private final String cardNumber;
+		private final PaymentStatus paymentStatus;
+	}
+
 }

--- a/src/main/java/com/order/orderlink/order/domain/Order.java
+++ b/src/main/java/com/order/orderlink/order/domain/Order.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.order.orderlink.common.entity.BaseTimeEntity;
 import com.order.orderlink.orderitem.domain.OrderItem;
+import com.order.orderlink.payment.domain.Payment;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Entity;
@@ -17,6 +18,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -62,6 +64,9 @@ public class Order extends BaseTimeEntity {
 	@Builder.Default
 	@OneToMany(mappedBy = "order", cascade = CascadeType.ALL)
 	private List<OrderItem> orderItems = new ArrayList<>();
+
+	@OneToOne(mappedBy = "order", cascade = CascadeType.ALL)
+	private Payment payment;
 
 	public void addOrderItem(OrderItem orderItem) {
 		orderItem.setOrder(this);

--- a/src/main/java/com/order/orderlink/order/presentation/OrderController.java
+++ b/src/main/java/com/order/orderlink/order/presentation/OrderController.java
@@ -1,6 +1,7 @@
 package com.order.orderlink.order.presentation;
 
-import org.springframework.http.ResponseEntity;
+import java.util.UUID;
+
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,9 +37,12 @@ public class OrderController {
 			orderService.getMyOrders(userDetails, page, size));
 	}
 
-	@GetMapping("/{id}")
-	public ResponseEntity<?> getOrder(@PathVariable("id") String id) {
-		return ResponseEntity.ok("getOrder(id) has been called!");
+	@GetMapping("/{orderId}")
+	public SuccessResponse<OrderResponse.GetOrderDetail> getOrderDetail(
+		@PathVariable("orderId") UUID orderId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		return SuccessResponse.success(SuccessCode.ORDER_GET_DETAIL_SUCCESS,
+			orderService.getOrderDetail(userDetails, orderId));
 	}
 
 	@PostMapping

--- a/src/main/java/com/order/orderlink/payment/domain/Payment.java
+++ b/src/main/java/com/order/orderlink/payment/domain/Payment.java
@@ -1,0 +1,59 @@
+package com.order.orderlink.payment.domain;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.order.orderlink.common.entity.BaseTimeEntity;
+import com.order.orderlink.order.domain.Order;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "p_payments")
+@EntityListeners(AuditingEntityListener.class)
+public class Payment extends BaseTimeEntity {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	private UUID id;
+
+	@OneToOne
+	@JoinColumn(name = "order_id")
+	private Order order;
+
+	@NotNull
+	private String cardNumber;
+
+	@NotNull
+	private String cardHolder;
+
+	@NotNull
+	private String expiryDate;
+
+	@NotNull
+	private Integer amount;
+
+	@NotNull
+	@Enumerated(EnumType.STRING)
+	private PaymentStatus status;
+
+	private String bank;
+
+}

--- a/src/main/java/com/order/orderlink/payment/domain/PaymentStatus.java
+++ b/src/main/java/com/order/orderlink/payment/domain/PaymentStatus.java
@@ -1,0 +1,12 @@
+package com.order.orderlink.payment.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum PaymentStatus {
+	COMPLETED("결제 완료"), CANCELED("결제 취소");
+
+	private final String value;
+}


### PR DESCRIPTION
- 소비자랑 가게 주인이 주문 상세 내역 확인
- payment 도메인 추가 및 일대일 연관관계 매핑
- 카드 번호는 마스킹해서 표현
```
{
    "code": 200,
    "message": "주문 상세 조회 성공입니다.",
    "data": {
        "orderId": "74e1eedf-7177-40b6-bdcb-5005d02ef946",
        "restaurantName": "꼰미고",
        "totalPrice": 25000,
        "deliveryAddress": "서울 강남구 테헤란로 123",
        "foods": [
            {
                "foodName": "마라탕",
                "price": 1000,
                "count": 2
            },
            {
                "foodName": "마라탕",
                "price": 1000,
                "count": 2
            }
        ],
        "status": "주문 승인",
        "createdAt": "2025-02-17T15:52:35.217409",
        "paymentPrice": 50000,
        "paymentBank": "Kakao Bank",
        "cardNumber": "************5678",
        "paymentStatus": "결제 완료"
    }
}
```