### PR TITLE
[Feat] 카테고리 추가, 음식점에 카테고리 등록, 카테고리 리스트 조회 기능 구현

### DIFF
--- a/src/main/java/com/order/orderlink/category/application/CategoryService.java
+++ b/src/main/java/com/order/orderlink/category/application/CategoryService.java
@@ -1,0 +1,63 @@
+package com.order.orderlink.category.application;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.order.orderlink.category.application.dtos.CategoryDTO;
+import com.order.orderlink.category.application.dtos.CategoryRequest;
+import com.order.orderlink.category.application.dtos.CategoryResponse;
+import com.order.orderlink.category.domain.Category;
+import com.order.orderlink.category.domain.RestaurantCategory;
+import com.order.orderlink.category.domain.repository.JpaCategoryRepository;
+import com.order.orderlink.category.domain.repository.JpaRestaurantCategoryRepository;
+import com.order.orderlink.common.enums.ErrorCode;
+import com.order.orderlink.common.exception.CategoryException;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CategoryService {
+	private final JpaCategoryRepository categoryRepository;
+	private final JpaRestaurantCategoryRepository restaurantCategoryRepository;
+
+	public CategoryResponse.Create createCategory(CategoryRequest.Create request) {
+		Category category = Category.builder()
+			.name(request.getName())
+			.build();
+		categoryRepository.save(category);
+		return CategoryResponse.Create.builder().categoryId(category.getId()).build();
+	}
+
+	public void createRestaurantCategory(CategoryRequest.RegisterRestaurantCategory request, UUID restaurantId) {
+		List<UUID> categoryIds = request.getCategoryIds();
+		for (UUID categoryId : categoryIds) {
+			Category category = categoryRepository.findById(categoryId)
+				.orElseThrow(() -> new CategoryException(ErrorCode.CATEGORY_NOT_FOUND));
+			RestaurantCategory restaurantCategory = RestaurantCategory.builder()
+				.categoryId(category.getId())
+				.restaurantId(restaurantId)
+				.build();
+			restaurantCategoryRepository.save(restaurantCategory);
+		}
+	}
+
+	@Transactional(readOnly = true)
+	public CategoryResponse.GetCateories getCategories() {
+		List<Category> categories = categoryRepository.findAll();
+		List<CategoryDTO> categoryDTOS = new ArrayList<>();
+		for (Category category : categories) {
+			CategoryDTO categoryDTO = CategoryDTO.builder().categoryId(category.getId())
+				.name(category.getName())
+				.createdAt(category.getCreatedAt())
+				.build();
+			categoryDTOS.add(categoryDTO);
+		}
+		return CategoryResponse.GetCateories.builder().categories(categoryDTOS).build();
+	}
+}

--- a/src/main/java/com/order/orderlink/category/application/dtos/CategoryDTO.java
+++ b/src/main/java/com/order/orderlink/category/application/dtos/CategoryDTO.java
@@ -1,0 +1,19 @@
+package com.order.orderlink.category.application.dtos;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CategoryDTO {
+	private UUID categoryId;
+	private String name;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/order/orderlink/category/application/dtos/CategoryRequest.java
+++ b/src/main/java/com/order/orderlink/category/application/dtos/CategoryRequest.java
@@ -1,0 +1,23 @@
+package com.order.orderlink.category.application.dtos;
+
+import java.util.List;
+import java.util.UUID;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class CategoryRequest {
+
+	@Getter
+	public static class Create {
+
+		@NotBlank
+		private String name;
+	}
+
+	@Getter
+	public static class RegisterRestaurantCategory {
+
+		private List<UUID> categoryIds;
+	}
+}

--- a/src/main/java/com/order/orderlink/category/application/dtos/CategoryResponse.java
+++ b/src/main/java/com/order/orderlink/category/application/dtos/CategoryResponse.java
@@ -1,0 +1,24 @@
+package com.order.orderlink.category.application.dtos;
+
+import java.util.List;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class CategoryResponse {
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class Create {
+		private final UUID categoryId;
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class GetCateories {
+		private final List<CategoryDTO> categories;
+	}
+}

--- a/src/main/java/com/order/orderlink/category/domain/Category.java
+++ b/src/main/java/com/order/orderlink/category/domain/Category.java
@@ -1,0 +1,43 @@
+package com.order.orderlink.category.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.order.orderlink.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "p_categories")
+@EntityListeners(AuditingEntityListener.class)
+public class Category extends BaseTimeEntity {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	private UUID id;
+
+	@NotNull
+	private String name;
+
+	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
+}
+

--- a/src/main/java/com/order/orderlink/category/domain/RestaurantCategory.java
+++ b/src/main/java/com/order/orderlink/category/domain/RestaurantCategory.java
@@ -1,0 +1,38 @@
+package com.order.orderlink.category.domain;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.order.orderlink.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "p_restaurant_categories")
+@EntityListeners(AuditingEntityListener.class)
+public class RestaurantCategory extends BaseTimeEntity {
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	private UUID id;
+
+	@NotNull
+	private UUID restaurantId;
+
+	@NotNull
+	private UUID categoryId;
+
+}

--- a/src/main/java/com/order/orderlink/category/domain/repository/JpaCategoryRepository.java
+++ b/src/main/java/com/order/orderlink/category/domain/repository/JpaCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.order.orderlink.category.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.order.orderlink.category.domain.Category;
+
+public interface JpaCategoryRepository extends JpaRepository<Category, UUID> {
+}

--- a/src/main/java/com/order/orderlink/category/domain/repository/JpaRestaurantCategoryRepository.java
+++ b/src/main/java/com/order/orderlink/category/domain/repository/JpaRestaurantCategoryRepository.java
@@ -1,0 +1,10 @@
+package com.order.orderlink.category.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.order.orderlink.category.domain.RestaurantCategory;
+
+public interface JpaRestaurantCategoryRepository extends JpaRepository<RestaurantCategory, UUID> {
+}

--- a/src/main/java/com/order/orderlink/category/presentation/CategoryController.java
+++ b/src/main/java/com/order/orderlink/category/presentation/CategoryController.java
@@ -1,0 +1,53 @@
+package com.order.orderlink.category.presentation;
+
+import java.util.UUID;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.order.orderlink.category.application.CategoryService;
+import com.order.orderlink.category.application.dtos.CategoryRequest;
+import com.order.orderlink.category.application.dtos.CategoryResponse;
+import com.order.orderlink.common.dtos.SuccessNonDataResponse;
+import com.order.orderlink.common.dtos.SuccessResponse;
+import com.order.orderlink.common.enums.SuccessCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+	private final CategoryService categoryService;
+
+	@PostMapping
+	@PreAuthorize("hasAuthority('ROLE_MASTER')")
+	public SuccessResponse<CategoryResponse.Create> createCategory(
+		@RequestBody CategoryRequest.Create request) {
+		return SuccessResponse.success(SuccessCode.CATEGORY_CREATE_SUCCESS,
+			categoryService.createCategory(request));
+	}
+
+	@PostMapping("/register")
+	@PreAuthorize("hasAnyAuthority('ROLE_MASTER', 'ROLE_OWNER')")
+	public SuccessNonDataResponse createRestaurantCategory(
+		@RequestBody CategoryRequest.RegisterRestaurantCategory request,
+		@RequestParam UUID restaurantId
+	) {
+		categoryService.createRestaurantCategory(request, restaurantId);
+		return SuccessNonDataResponse.success(SuccessCode.CATEGORY_REGISTER_SUCCESS);
+	}
+
+	@GetMapping
+	@PreAuthorize("hasAnyAuthority('ROLE_MASTER', 'ROLE_OWNER', 'ROLE_CUSTOMER')")
+	public SuccessResponse<CategoryResponse.GetCateories> getCategories(
+	) {
+		return SuccessResponse.success(SuccessCode.CATEGORY_GET_SUCCESS,
+			categoryService.getCategories());
+	}
+}

--- a/src/main/java/com/order/orderlink/category/presentation/CategoryController.java
+++ b/src/main/java/com/order/orderlink/category/presentation/CategoryController.java
@@ -34,7 +34,7 @@ public class CategoryController {
 	}
 
 	@PostMapping("/register")
-	@PreAuthorize("hasAnyAuthority('ROLE_MASTER', 'ROLE_OWNER')")
+	@PreAuthorize("hasAuthority('ROLE_MASTER')")
 	public SuccessNonDataResponse createRestaurantCategory(
 		@RequestBody CategoryRequest.RegisterRestaurantCategory request,
 		@RequestParam UUID restaurantId
@@ -44,7 +44,6 @@ public class CategoryController {
 	}
 
 	@GetMapping
-	@PreAuthorize("hasAnyAuthority('ROLE_MASTER', 'ROLE_OWNER', 'ROLE_CUSTOMER')")
 	public SuccessResponse<CategoryResponse.GetCateories> getCategories(
 	) {
 		return SuccessResponse.success(SuccessCode.CATEGORY_GET_SUCCESS,

--- a/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
+++ b/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
@@ -63,7 +63,7 @@ public class SecurityConfig {
 			)
 			.authorizeHttpRequests(authorize -> authorize
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
-				.requestMatchers("/api/auth/login", "/api/users").permitAll()
+				.requestMatchers("/api/auth/login", "/api/users", "/api/categories").permitAll()
 				.anyRequest().authenticated()
 			);
 

--- a/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
@@ -30,7 +30,9 @@ public enum ErrorCode {
 
 	// DELIVERY DETAIL
 	DELIVERY_DETAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "배송 상세 정보를 찾을 수 없습니다."),
-	;
+
+	//Category
+	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리가 존재하지 않습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -40,7 +40,11 @@ public enum SuccessCode {
 	DELIVERY_DETAIL_READ_SUCCESS(HttpStatus.OK, "배송지 상세 조회 성공입니다."),
 	DELIVERY_DETAIL_UPDATE_SUCCESS(HttpStatus.OK, "배송지 수정 성공입니다."),
 	DELIVERY_DETAIL_DELETE_SUCCESS(HttpStatus.OK, "배송지 삭제 성공입니다."),
-	;
+
+	//Category
+	CATEGORY_CREATE_SUCCESS(HttpStatus.OK, "카테고리 새로 추가 성공입니다"),
+	CATEGORY_REGISTER_SUCCESS(HttpStatus.OK, "음식점 카테고리 등록 성공입니다"),
+	CATEGORY_GET_SUCCESS(HttpStatus.OK, "카테고리 리스트 조회 성공입니다");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/common/exception/CategoryException.java
+++ b/src/main/java/com/order/orderlink/common/exception/CategoryException.java
@@ -1,4 +1,9 @@
 package com.order.orderlink.common.exception;
 
-public class CategoryException {
+import com.order.orderlink.common.enums.ErrorCode;
+
+public class CategoryException extends BaseException {
+	public CategoryException(ErrorCode errorCode) {
+		super(errorCode.getStatus(), errorCode.getMessage());
+	}
 }

--- a/src/main/java/com/order/orderlink/common/exception/CategoryException.java
+++ b/src/main/java/com/order/orderlink/common/exception/CategoryException.java
@@ -1,0 +1,4 @@
+package com.order.orderlink.common.exception;
+
+public class CategoryException {
+}


### PR DESCRIPTION
- restaurantcategory중간 테이블을 두어 음식점과 카테고리의 관계를 맺을 수 있게 하였습니다. 
- 추후 카테고리 별 음식점을 조회하기 위해 단방향으로 카테고리 - restaurantCategory 일대다 연관관계 매핑하였습니다. 
- 카테고리 추가는 새로운 카테고리를 추가하는 것이고,  카테고리 등록은 음식점에 카테고리를 등록하는 것입니다. 
---
<img width="617" alt="image" src="https://github.com/user-attachments/assets/ebb68c4c-d43d-4eb7-aaf5-d827339dabf3" />

---
<img width="802" alt="image" src="https://github.com/user-attachments/assets/b29c24fc-47cd-460d-9721-b7a015ee9e0c" />

---
<img width="615" alt="image" src="https://github.com/user-attachments/assets/0419d00f-d1ed-4425-80c5-2ef3cac06cfa" />
