### PR TITLE
[Feat] AI를 통해 음식 설명을 추천받는 API 추가

### DIFF
--- a/src/main/java/com/order/orderlink/ai/application/AiApiService.java
+++ b/src/main/java/com/order/orderlink/ai/application/AiApiService.java
@@ -1,0 +1,107 @@
+package com.order.orderlink.ai.application;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.order.orderlink.ai.application.dtos.AiApiRequest;
+import com.order.orderlink.ai.application.dtos.AiApiResponse;
+import com.order.orderlink.ai.domain.AiApiLog;
+import com.order.orderlink.ai.domain.repository.AiApiLogRepository;
+import com.order.orderlink.common.enums.ErrorCode;
+import com.order.orderlink.common.exception.AiApiException;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "AI API Service")
+@Service
+@RequiredArgsConstructor
+public class AiApiService {
+
+	private final WebClient aiWebClient;
+	private final AiApiLogRepository aiApiLogRepository;
+
+	@Value("${ai.api.key}")
+	private String apiKey;
+
+	public AiApiResponse.GenerateDescription generateDescription(UUID userId,
+		AiApiRequest.GenerateDescription requestDto) {
+
+		int MAX_INPUT_LENGTH = 100; // AI API 요청 텍스트 최대 길이
+
+		String baseText = requestDto.getBaseText();
+
+		if (baseText.length() > MAX_INPUT_LENGTH) {
+			baseText = baseText.substring(0, MAX_INPUT_LENGTH);
+			log.info("요청 텍스트가 {}자를 초과하여 {}자로 자름", MAX_INPUT_LENGTH, baseText.length());
+		}
+
+		// 요청 텍스트에 추가 지시문 첨부
+		String finalRequestText = baseText + " 답변을 최대한 간결하게 50자 이하로";
+
+		// AI API에 보낼 payload 구성 (요청 JSON 구조)
+		Map<String, Object> payload = new HashMap<>();
+		Map<String, Object> contentMap = new HashMap<>();
+		Map<String, String> part = new HashMap<>();
+		part.put("text", finalRequestText);
+		contentMap.put("parts", new Map[] {part}); // parts 는 배열 형태로 전달
+		payload.put("contents", new Map[] {contentMap});
+
+		log.info("상품 설명 생성 요청 userId: {}, input: {}", userId, baseText);
+		String responseBody = aiWebClient.post()
+			.uri(uriBuilder -> uriBuilder
+				.path("/v1beta/models/gemini-1.5-flash-latest:generateContent")
+				.queryParam("key", apiKey)
+				.build())
+			.header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+			.bodyValue(payload)
+			.retrieve()
+			.bodyToMono(String.class)
+			.block();
+
+		String recommendedDescription = extractDescription(responseBody);
+		log.info("상품 설명 생성 응답: {}", recommendedDescription);
+
+		// DB에 API 로그 저장
+		AiApiLog aiApiLog = AiApiLog.builder()
+			.userId(userId)
+			.requestText(baseText)
+			.responseText(recommendedDescription)
+			.build();
+		aiApiLogRepository.save(aiApiLog);
+
+		return new AiApiResponse.GenerateDescription(recommendedDescription);
+	}
+
+	private String extractDescription(String responseBody) {
+		// 응답 JSON 구조에서 추천 설명 추출
+		// 예시: {"contents":[{"parts":[{"text":"상품 설명"}]}]}
+		try {
+			ObjectMapper objectMapper = new ObjectMapper();
+			JsonNode root = objectMapper.readTree(responseBody);
+			JsonNode candidates = root.path("candidates");
+			if (candidates.isArray() && !candidates.isEmpty()) {
+				JsonNode candidate = candidates.get(0);
+				JsonNode content = candidate.path("content");
+				JsonNode parts = content.path("parts");
+				if (parts.isArray() && !parts.isEmpty()) {
+					return parts.get(0).path("text").asText();
+				}
+			}
+		} catch (Exception e) {
+			log.error("AI API 응답 JSON 파싱 오류", e);
+			throw new AiApiException(ErrorCode.AI_API_RESPONSE_PARSING_ERROR);
+		}
+		return "";
+	}
+
+}

--- a/src/main/java/com/order/orderlink/ai/application/dtos/AiApiRequest.java
+++ b/src/main/java/com/order/orderlink/ai/application/dtos/AiApiRequest.java
@@ -1,0 +1,16 @@
+package com.order.orderlink.ai.application.dtos;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+public class AiApiRequest {
+
+	@Getter
+	public static class GenerateDescription {
+		@NotBlank(message = "입력 텍스트는 필수입니다.")
+		@Size(max = 100, message = "입력 텍스트는 최대 100자까지 입력 가능합니다.")
+		private String baseText;
+	}
+
+}

--- a/src/main/java/com/order/orderlink/ai/application/dtos/AiApiResponse.java
+++ b/src/main/java/com/order/orderlink/ai/application/dtos/AiApiResponse.java
@@ -1,0 +1,14 @@
+package com.order.orderlink.ai.application.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+public class AiApiResponse {
+
+	@Getter
+	@AllArgsConstructor
+	public static class GenerateDescription {
+		private String description;
+	}
+
+}

--- a/src/main/java/com/order/orderlink/ai/domain/AiApiLog.java
+++ b/src/main/java/com/order/orderlink/ai/domain/AiApiLog.java
@@ -1,0 +1,49 @@
+package com.order.orderlink.ai.domain;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.order.orderlink.common.entity.BaseTimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_ai_api_log")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AiApiLog extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	@Column(name = "id", updatable = false, nullable = false)
+	private UUID id;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "request_text", columnDefinition = "text", nullable = false)
+	private String requestText;
+
+	@Column(name = "response_text", columnDefinition = "text", nullable = false)
+	private String responseText;
+
+	@Builder
+	public AiApiLog(UUID userId, String requestText, String responseText) {
+		this.userId = userId;
+		this.requestText = requestText;
+		this.responseText = responseText;
+	}
+}

--- a/src/main/java/com/order/orderlink/ai/domain/repository/AiApiLogRepository.java
+++ b/src/main/java/com/order/orderlink/ai/domain/repository/AiApiLogRepository.java
@@ -1,0 +1,10 @@
+package com.order.orderlink.ai.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.order.orderlink.ai.domain.AiApiLog;
+
+public interface AiApiLogRepository extends JpaRepository<AiApiLog, UUID> {
+}

--- a/src/main/java/com/order/orderlink/ai/presentation/AiApiController.java
+++ b/src/main/java/com/order/orderlink/ai/presentation/AiApiController.java
@@ -1,0 +1,51 @@
+package com.order.orderlink.ai.presentation;
+
+import java.util.UUID;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.order.orderlink.ai.application.AiApiService;
+import com.order.orderlink.ai.application.dtos.AiApiRequest;
+import com.order.orderlink.ai.application.dtos.AiApiResponse;
+import com.order.orderlink.common.auth.UserDetailsImpl;
+import com.order.orderlink.common.dtos.SuccessResponse;
+import com.order.orderlink.common.enums.SuccessCode;
+import com.order.orderlink.common.exception.AiApiException;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/ai")
+@RequiredArgsConstructor
+public class AiApiController {
+
+	private final AiApiService aiApiService;
+
+	/**
+	 * 음식 설명 생성 요청
+	 * @param userDetails 로그인한 사용자 정보
+	 * @param request AiApiRequest.GenerateDescription - 요청 DTO
+	 * @return SuccessResponse<AiApiResponse.GenerateDescription> - 응답 DTO
+	 * @throws AiApiException AI API 응답 파싱 실패시
+	 * @see AiApiRequest.GenerateDescription
+	 * @see AiApiResponse.GenerateDescription
+	 * @see AiApiService#generateDescription(UUID, AiApiRequest.GenerateDescription)
+	 * @author Jihwan
+	 */
+	@PostMapping("/generate-description")
+	@PreAuthorize("hasAuthority('ROLE_OWNER')")
+	public SuccessResponse<AiApiResponse.GenerateDescription> generateDescription(
+		@AuthenticationPrincipal UserDetailsImpl userDetails,
+		@Valid @RequestBody AiApiRequest.GenerateDescription request) {
+		UUID userId = userDetails.getUser().getId();
+		return SuccessResponse.success(SuccessCode.AI_DESCRIPTION_GENERATE_SUCCESS,
+			aiApiService.generateDescription(userId, request));
+	}
+
+}

--- a/src/main/java/com/order/orderlink/common/config/AiWebClientConfig.java
+++ b/src/main/java/com/order/orderlink/common/config/AiWebClientConfig.java
@@ -1,0 +1,20 @@
+package com.order.orderlink.common.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class AiWebClientConfig {
+
+	@Bean
+	@Qualifier("aiWebClient")
+	public WebClient aiWebClient(WebClient.Builder builder, @Value("${ai.api.base-url}") String aiBaseUrl) {
+		return builder
+			.baseUrl(aiBaseUrl) // 기본 URL 설정
+			.defaultHeader("Content-Type", "application/json") // 기본 헤더 설정
+			.build();
+	}
+}

--- a/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
@@ -34,8 +34,11 @@ public enum ErrorCode {
 	//Category
 	CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "카테고리가 존재하지 않습니다."),
 
-    // FOOD
-    FOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "음식을 찾을 수 없습니다.");
+	// FOOD
+	FOOD_NOT_FOUND(HttpStatus.NOT_FOUND, "음식을 찾을 수 없습니다."),
+
+	// AI
+	AI_API_RESPONSE_PARSING_ERROR(HttpStatus.NOT_FOUND, "음식 설명 생성 도중 오류가 발생했습니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -34,7 +34,7 @@ public enum SuccessCode {
 
 	// FOOD
 	FOOD_CREATE_SUCCESS(HttpStatus.OK, "음식 등록 성공입니다."),
-    FOOD_UPDATE_SUCCESS(HttpStatus.OK, "음식 수정 성공입니다."),
+	FOOD_UPDATE_SUCCESS(HttpStatus.OK, "음식 수정 성공입니다."),
 
 	// ADDRESS
 	ADDRESS_CREATE_SUCCESS(HttpStatus.OK, "배송지 등록 성공입니다."),
@@ -43,12 +43,15 @@ public enum SuccessCode {
 	ADDRESS_UPDATE_SUCCESS(HttpStatus.OK, "배송지 수정 성공입니다."),
 	ADDRESS_DELETE_SUCCESS(HttpStatus.OK, "배송지 삭제 성공입니다."),
 
-	//Category
+	// CATEGORY
 	CATEGORY_CREATE_SUCCESS(HttpStatus.OK, "카테고리 새로 추가 성공입니다"),
 	CATEGORY_REGISTER_SUCCESS(HttpStatus.OK, "음식점 카테고리 등록 성공입니다"),
 	CATEGORY_GET_SUCCESS(HttpStatus.OK, "카테고리 리스트 조회 성공입니다"),
 	CATEGORY_DELETE_SUCCESS(HttpStatus.OK, "카테고리 삭제 성공입니다"),
-	CATEGORY_UPDATE_SUCCESS(HttpStatus.OK, "카테고리 수정 성공입니다");
+	CATEGORY_UPDATE_SUCCESS(HttpStatus.OK, "카테고리 수정 성공입니다"),
+
+	// AI
+	AI_DESCRIPTION_GENERATE_SUCCESS(HttpStatus.OK, "음식 설명 생성 성공입니다.");
 
 	private final HttpStatus status;
 	private final String message;

--- a/src/main/java/com/order/orderlink/common/exception/AiApiException.java
+++ b/src/main/java/com/order/orderlink/common/exception/AiApiException.java
@@ -1,0 +1,10 @@
+package com.order.orderlink.common.exception;
+
+import com.order.orderlink.common.enums.ErrorCode;
+
+public class AiApiException extends BaseException {
+
+	public AiApiException(ErrorCode errorCode) {
+		super(errorCode.getStatus(), errorCode.getMessage());
+	}
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -20,3 +20,6 @@ logging.level.org.hibernate.SQL=DEBUG
 logging.level.org.hibernate.type.descriptor.sql=TRACE
 # jwt config
 jwt.secret.key=${JWT_SECRET_KEY}
+# ai api config
+ai.api.base-url=https://generativelanguage.googleapis.com
+ai.api.key=${AI_API_KEY}


### PR DESCRIPTION
- [x] AI에게 음식 설명을 추천받는 API 추가했습니다.
- 음식(상품)을 등록하는 주체가 OWNER라서, 음식 설명 추천 요청도 OWNER만 가능하게 했습니다.
- 요구사항에 맞게 음식 설명은 50자 이하로 생성되게 만들었으며, 클라이언트 요청 본문 텍스트도 100자로 제한하였습니다.

<img width="729" alt="스크린샷 2025-02-21 오후 12 42 45" src="https://github.com/user-attachments/assets/24164714-c34b-4177-99e6-9feca7d35d48" />
