### PR TITLE
[Feat] 리뷰 등록/조회(목록, 상세)/수정/삭제 API 추가

### DIFF
--- a/src/main/java/com/order/orderlink/address/domain/Address.java
+++ b/src/main/java/com/order/orderlink/address/domain/Address.java
@@ -2,6 +2,7 @@ package com.order.orderlink.address.domain;
 
 import java.util.UUID;
 
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -25,6 +26,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "p_addresses")
+@SQLRestriction("deleted_at IS NULL")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Address extends BaseTimeEntity {

--- a/src/main/java/com/order/orderlink/address/presentation/AddressController.java
+++ b/src/main/java/com/order/orderlink/address/presentation/AddressController.java
@@ -105,7 +105,7 @@ public class AddressController {
 
 		Pageable pageable = PageRequest.of(page - 1, size, sortObj);
 		UUID userId = userDetails.getUser().getId();
-		return SuccessResponse.success(SuccessCode.ADDRESS_READ_ALL_SUCCESS,
+		return SuccessResponse.success(SuccessCode.ADDRESS_GET_SUCCESS,
 			addressService.getAddresses(userId, pageable));
 	}
 
@@ -121,7 +121,7 @@ public class AddressController {
 	public SuccessResponse<AddressResponse.Read> getAddressInfo(@PathVariable("id") UUID id,
 		@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		UUID currentUserId = userDetails.getUser().getId();
-		return SuccessResponse.success(SuccessCode.ADDRESS_READ_SUCCESS,
+		return SuccessResponse.success(SuccessCode.ADDRESS_GET_DETAIL_SUCCESS,
 			addressService.getAddressInfo(id, currentUserId));
 	}
 

--- a/src/main/java/com/order/orderlink/address/presentation/AddressController.java
+++ b/src/main/java/com/order/orderlink/address/presentation/AddressController.java
@@ -71,7 +71,7 @@ public class AddressController {
 		@AuthenticationPrincipal UserDetailsImpl userDetails,
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(defaultValue = "createdAt,desc") String sort) {
+		@RequestParam(required = false) String sort) {
 
 		if (page < 1) {
 			page = 1;
@@ -84,25 +84,39 @@ public class AddressController {
 		Sort sortObj = null;
 		if (sort != null && !sort.trim().isEmpty()) {
 			String[] sortParts = sort.split(",");
-
 			if (sortParts.length == 2) {
 				String fieldInput = sortParts[0].trim();
 				String orderInput = sortParts[1].trim().toLowerCase();
-
-				if (!fieldInput.isEmpty() && (orderInput.equals("asc") || orderInput.equals("desc"))) {
-					sortObj = orderInput.equals("asc") ?
-						Sort.by(fieldInput).ascending() : Sort.by(fieldInput).descending();
+				// field가 "id", "createdAt", "updatedAt" 중 하나이면 사용,
+				// 아니면 기본 정렬 적용
+				if (fieldInput.equals("id") || fieldInput.equals("createdAt") || fieldInput.equals("updatedAt")) {
+					if (orderInput.equals("asc")) {
+						sortObj = Sort.by(fieldInput).ascending();
+					} else if (orderInput.equals("desc")) {
+						sortObj = Sort.by(fieldInput).descending();
+					}
+				} else {
+					// 유효하지 않은 field이면 기본값 적용
+					sortObj = Sort.by(
+						Sort.Order.desc("createdAt"),
+						Sort.Order.desc("updatedAt")
+					);
 				}
+			} else {
+				sortObj = Sort.by(
+					Sort.Order.desc("createdAt"),
+					Sort.Order.desc("updatedAt")
+				);
 			}
-		}
-
-		if (sortObj == null) {
+		} else {
 			sortObj = Sort.by(
 				Sort.Order.desc("createdAt"),
 				Sort.Order.desc("updatedAt")
 			);
 		}
 
+		// 1-based 페이지 번호를 0-based로 변환
+		assert sortObj != null;
 		Pageable pageable = PageRequest.of(page - 1, size, sortObj);
 		UUID userId = userDetails.getUser().getId();
 		return SuccessResponse.success(SuccessCode.ADDRESS_GET_SUCCESS,

--- a/src/main/java/com/order/orderlink/ai/domain/AiApiLog.java
+++ b/src/main/java/com/order/orderlink/ai/domain/AiApiLog.java
@@ -2,6 +2,7 @@ package com.order.orderlink.ai.domain;
 
 import java.util.UUID;
 
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.annotations.UuidGenerator;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -21,6 +22,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @Entity
 @Table(name = "p_ai_api_log")
+@SQLRestriction("deleted_at IS NULL")
 @EntityListeners(AuditingEntityListener.class)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AiApiLog extends BaseTimeEntity {

--- a/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
+++ b/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
@@ -63,25 +63,22 @@ public class SecurityConfig {
 				.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
 			)
 			.authorizeHttpRequests(authorize -> authorize
-				.requestMatchers(PathRequest.toStaticResources().atCommonLocations())
-				.permitAll() // resources 접근 허용 설정
-				.requestMatchers("/api/auth/login", "/api/users", "/api/categories", "/api/foods/**", "/api/foods")
-				.permitAll()
-				.requestMatchers(HttpMethod.DELETE, "/api/foods/**")
-				.hasAnyAuthority("ROLE_OWNER")
-				.requestMatchers(HttpMethod.POST, "/api/foods")
-				.hasAnyAuthority("ROLE_OWNER")
-				.requestMatchers(HttpMethod.POST, "/api/foods/**")
-				.hasAnyAuthority("ROLE_OWNER")
-				.requestMatchers(HttpMethod.DELETE, "/api/foods/**")
-				.hasAnyAuthority("ROLE_OWNER")
+				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
+				.requestMatchers("/api/auth/login", "/api/users", "/api/categories", "/api/foods/**",
+					"/api/foods").permitAll()
+				.requestMatchers(HttpMethod.DELETE, "/api/foods/**").hasAnyAuthority("ROLE_OWNER")
+				.requestMatchers(HttpMethod.POST, "/api/foods").hasAnyAuthority("ROLE_OWNER")
+				.requestMatchers(HttpMethod.POST, "/api/foods/**").hasAnyAuthority("ROLE_OWNER")
+				.requestMatchers(HttpMethod.DELETE, "/api/foods/**").hasAnyAuthority("ROLE_OWNER")
 				.requestMatchers(PathRequest.toStaticResources().atCommonLocations()).permitAll() // resources 접근 허용 설정
 				.requestMatchers("/api/auth/login", "/api/users", "/api/categories").permitAll()
 				.requestMatchers(HttpMethod.GET, "/api/restaurants/**").permitAll()
 				.requestMatchers(HttpMethod.POST, "/api/restaurants").hasAuthority("ROLE_MASTER")
 				.requestMatchers(HttpMethod.PUT, "/api/restaurants/**").hasAuthority("ROLE_MASTER")
 				.requestMatchers(HttpMethod.DELETE, "/api/restaurants/**").hasAuthority("ROLE_MASTER")
-				.anyRequest().authenticated()
+				.requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
+				.anyRequest()
+				.authenticated()
 			);
 
 		// 필터 추가

--- a/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
+++ b/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
@@ -77,8 +77,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.PUT, "/api/restaurants/**").hasAuthority("ROLE_MASTER")
 				.requestMatchers(HttpMethod.DELETE, "/api/restaurants/**").hasAuthority("ROLE_MASTER")
 				.requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
-				.anyRequest()
-				.authenticated()
+				.anyRequest().authenticated()
 			);
 
 		// 필터 추가

--- a/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
@@ -44,6 +44,11 @@ public enum ErrorCode {
 	// AI
 	AI_API_RESPONSE_PARSING_ERROR(HttpStatus.NOT_FOUND, "음식 설명 생성 도중 오류가 발생했습니다."),
 
+	// REVIEW
+	REVIEW_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 작성된 리뷰가 존재합니다."),
+	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "리뷰를 찾을 수 없습니다."),
+	REVIEW_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "해당 리뷰에 대한 권한이 없습니다."),
+
 	;
 
 	private final HttpStatus status;

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -73,6 +73,7 @@ public enum SuccessCode {
 	// REVIEW
 	REVIEW_CREATE_SUCCESS(HttpStatus.OK, "리뷰 등록 성공입니다."),
 	REVIEW_GET_SUCCESS(HttpStatus.OK, "리뷰 목록 조회 성공입니다."),
+	REVIEW_GET_DETAIL_SUCCESS(HttpStatus.OK, "리뷰 상세 조회 성공입니다."),
 	REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "리뷰 수정 성공입니다."),
 	REVIEW_DELETE_SUCCESS(HttpStatus.OK, "리뷰 삭제 성공입니다."),
 

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -14,8 +14,8 @@ public enum SuccessCode {
 
 	// USER
 	USER_CREATE_SUCCESS(HttpStatus.OK, "회원 가입 성공입니다."),
-	USER_READ_ALL_SUCCESS(HttpStatus.OK, "전체 회원 조회 성공입니다."),
-	USER_READ_SUCCESS(HttpStatus.OK, "회원 정보 조회 성공입니다."),
+	USER_GET_SUCCESS(HttpStatus.OK, "회원 목록 조회 성공입니다."),
+	USER_GET_DETAIL_SUCCESS(HttpStatus.OK, "회원 상세 조회 성공입니다."),
 	USER_UPDATE_SUCCESS(HttpStatus.OK, "회원 정보 수정 성공입니다."),
 	USER_PASSWORD_UPDATE_SUCCESS(HttpStatus.OK, "비밀번호 변경 성공입니다."),
 	USER_DELETE_SUCCESS(HttpStatus.OK, "회원 삭제 성공입니다."),
@@ -41,8 +41,8 @@ public enum SuccessCode {
 
 	// ADDRESS
 	ADDRESS_CREATE_SUCCESS(HttpStatus.OK, "배송지 등록 성공입니다."),
-	ADDRESS_READ_ALL_SUCCESS(HttpStatus.OK, "배송지 목록 조회 성공입니다."),
-	ADDRESS_READ_SUCCESS(HttpStatus.OK, "배송지 상세 조회 성공입니다."),
+	ADDRESS_GET_SUCCESS(HttpStatus.OK, "배송지 목록 조회 성공입니다."),
+	ADDRESS_GET_DETAIL_SUCCESS(HttpStatus.OK, "배송지 상세 조회 성공입니다."),
 	ADDRESS_UPDATE_SUCCESS(HttpStatus.OK, "배송지 수정 성공입니다."),
 	ADDRESS_DELETE_SUCCESS(HttpStatus.OK, "배송지 삭제 성공입니다."),
 
@@ -72,6 +72,7 @@ public enum SuccessCode {
 
 	// REVIEW
 	REVIEW_CREATE_SUCCESS(HttpStatus.OK, "리뷰 등록 성공입니다."),
+	REVIEW_GET_SUCCESS(HttpStatus.OK, "리뷰 목록 조회 성공입니다."),
 	REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "리뷰 수정 성공입니다."),
 	REVIEW_DELETE_SUCCESS(HttpStatus.OK, "리뷰 삭제 성공입니다."),
 

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -53,8 +53,8 @@ public enum SuccessCode {
 	CATEGORY_DELETE_SUCCESS(HttpStatus.OK, "카테고리 삭제 성공입니다"),
 	CATEGORY_UPDATE_SUCCESS(HttpStatus.OK, "카테고리 수정 성공입니다"),
 
-  // RESTAURANT
-  RESTAURANT_CREATE_SUCCESS(HttpStatus.OK, "음식점 등록 성공입니다."),
+	// RESTAURANT
+	RESTAURANT_CREATE_SUCCESS(HttpStatus.OK, "음식점 등록 성공입니다."),
 	RESTAURANTS_GET_SUCCESS(HttpStatus.OK, "전체 음식점 조회 성공입니다."),
 	RESTAURANT_GET_SUCCESS(HttpStatus.OK, "음식점 조회 성공입니다."),
 
@@ -69,6 +69,11 @@ public enum SuccessCode {
 
 	//s3
 	FOOD_UPLOAD_IMG_SUCCESS(HttpStatus.OK, "음식 사진 등록 성공입니다."),
+
+	// REVIEW
+	REVIEW_CREATE_SUCCESS(HttpStatus.OK, "리뷰 등록 성공입니다."),
+	REVIEW_UPDATE_SUCCESS(HttpStatus.OK, "리뷰 수정 성공입니다."),
+	REVIEW_DELETE_SUCCESS(HttpStatus.OK, "리뷰 삭제 성공입니다."),
 
 	;
 

--- a/src/main/java/com/order/orderlink/common/exception/ReviewException.java
+++ b/src/main/java/com/order/orderlink/common/exception/ReviewException.java
@@ -1,0 +1,10 @@
+package com.order.orderlink.common.exception;
+
+import com.order.orderlink.common.enums.ErrorCode;
+
+public class ReviewException extends BaseException {
+
+	public ReviewException(ErrorCode errorCode) {
+		super(errorCode.getStatus(), errorCode.getMessage());
+	}
+}

--- a/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
@@ -1,21 +1,28 @@
 package com.order.orderlink.restaurant.domain;
 
-import com.order.orderlink.common.auth.util.LocalTimeToStringConverter;
-import com.order.orderlink.common.entity.BaseTimeEntity;
-import com.order.orderlink.food.domain.Food;
-import jakarta.persistence.*;
-import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.UuidGenerator;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
+
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.order.orderlink.common.auth.util.LocalTimeToStringConverter;
+import com.order.orderlink.common.entity.BaseTimeEntity;
+import com.order.orderlink.food.domain.Food;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Convert;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor
@@ -26,52 +33,65 @@ import java.util.UUID;
 @EntityListeners(AuditingEntityListener.class)
 public class Restaurant extends BaseTimeEntity {
 
-    @Id
-    @UuidGenerator(style = UuidGenerator.Style.AUTO)
-    private UUID id;
+	@Id
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	private UUID id;
 
-    @Column(name = "name", nullable = false)
-    private String name;
+	@Column(name = "name", nullable = false)
+	private String name;
 
-    @Column(name = "address", unique = true, nullable = false)
-    private String address;
+	@Column(name = "address", unique = true, nullable = false)
+	private String address;
 
-    @Column(name = "phone", unique = true, nullable = false)
-    private String phone;
+	@Column(name = "phone", unique = true, nullable = false)
+	private String phone;
 
-    @Column(name = "description")
-    private String description;
+	@Column(name = "description")
+	private String description;
 
-    @Convert(converter = LocalTimeToStringConverter.class)
-    @Column(name = "open_time", nullable = false)
-    private LocalTime openTime;
+	@Convert(converter = LocalTimeToStringConverter.class)
+	@Column(name = "open_time", nullable = false)
+	private LocalTime openTime;
 
-    @Convert(converter = LocalTimeToStringConverter.class)
-    @Column(name = "close_time", nullable = false)
-    private LocalTime closeTime;
+	@Convert(converter = LocalTimeToStringConverter.class)
+	@Column(name = "close_time", nullable = false)
+	private LocalTime closeTime;
 
-    @Builder.Default
-    @Column(name = "business_status", nullable = false)
-    private boolean businessStatus = true;
+	@Builder.Default
+	@Column(name = "business_status", nullable = false)
+	private boolean businessStatus = true;
 
-    @Column(name = "owner_name", nullable = false)
-    private String ownerName;
+	@Column(name = "owner_name", nullable = false)
+	private String ownerName;
 
-    @Column(name = "business_reg_num", unique = true, nullable = false)
-    private String businessRegNum;
+	@Column(name = "business_reg_num", unique = true, nullable = false)
+	private String businessRegNum;
 
-    @Builder.Default
-    @Column(name = "avg_rating", nullable = false)
-    private Double avgRating = 0.0;
+	@Builder.Default
+	@Column(name = "avg_rating", nullable = false)
+	private Double avgRating = 0.0;
 
-    @Builder.Default
-    @Column(name = "rating_sum", nullable = false)
-    private Double ratingSum = 0.0;
+	@Builder.Default
+	@Column(name = "rating_sum", nullable = false)
+	private Double ratingSum = 0.0;
 
-    @Builder.Default
-    @Column(name = "rating_count", nullable = false)
-    private Integer ratingCount = 0;
+	@Builder.Default
+	@Column(name = "rating_count", nullable = false)
+	private Integer ratingCount = 0;
 
-    @OneToMany(mappedBy = "restaurant")
-    private List<Food> foods = new ArrayList<>();
+	@OneToMany(mappedBy = "restaurant")
+	private List<Food> foods = new ArrayList<>();
+
+	public void updateRatingSum(Double newRatingSum) {
+		this.ratingSum = newRatingSum;
+	}
+
+	public void updateRatingCount(Integer newRatingCount) {
+		this.ratingCount = newRatingCount;
+	}
+
+	public void updateAvgRating(Double newAvgRating) {
+		this.avgRating = newAvgRating;
+	}
+
 }

--- a/src/main/java/com/order/orderlink/review/application/ReviewService.java
+++ b/src/main/java/com/order/orderlink/review/application/ReviewService.java
@@ -1,0 +1,151 @@
+package com.order.orderlink.review.application;
+
+import java.util.UUID;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.order.orderlink.common.enums.ErrorCode;
+import com.order.orderlink.common.exception.OrderException;
+import com.order.orderlink.common.exception.RestaurantException;
+import com.order.orderlink.common.exception.ReviewException;
+import com.order.orderlink.order.domain.Order;
+import com.order.orderlink.order.domain.repository.OrderRepository;
+import com.order.orderlink.restaurant.domain.Restaurant;
+import com.order.orderlink.restaurant.domain.repository.RestaurantRepository;
+import com.order.orderlink.review.application.dtos.ReviewRequest;
+import com.order.orderlink.review.application.dtos.ReviewResponse;
+import com.order.orderlink.review.domain.Review;
+import com.order.orderlink.review.domain.repository.ReviewRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+	private final ReviewRepository reviewRepository;
+	private final OrderRepository orderRepository;
+	private final RestaurantRepository restaurantRepository;
+
+	/**
+	 * 리뷰 등록:
+	 * 주문자만 리뷰를 작성할 수 있으며, 한 주문당 한 개의 리뷰만 작성가능.
+	 * 리뷰는 해당 주문을 한 음식점에 대해서 리뷰를 작성.
+	 * 주문에 대한 리뷰가 이미 존재하면 예외 발생.
+	 * 주문의 userId와 로그인한 사용자가 동일한 경우에만 작성 가능.
+	 * @param orderId 주문 ID
+	 * @param currentUserId 로그인한 사용자 ID
+	 * @param request 리뷰 생성 요청
+	 * @return 생성된 리뷰 ID
+	 * @throws OrderException 주문이 존재하지 않는 경우
+	 * @throws ReviewException 리뷰 작성이 허용되지 않는 경우, 이미 리뷰가 작성된 경우
+	 * @throws RestaurantException 음식점이 존재하지 않는 경우
+	 * @author Jihwan
+	 */
+	public ReviewResponse.Create createReview(UUID orderId, UUID currentUserId, ReviewRequest.Create request) {
+
+		// 주문 조회
+		Order order = orderRepository.findById(orderId)
+			.orElseThrow(() -> new OrderException(ErrorCode.ORDER_NOT_FOUND));
+
+		// 주문자와 현재 로그인한 사용자가 동일한지 확인
+		if (!order.getUserId().equals(currentUserId)) {
+			throw new ReviewException(ErrorCode.REVIEW_NOT_ALLOWED);
+		}
+
+		// 이미 특정 주문에 리뷰가 작성되었는지 확인
+		if (reviewRepository.existsByOrderId(orderId)) {
+			throw new ReviewException(ErrorCode.REVIEW_ALREADY_EXISTS);
+		}
+
+		UUID restaurantId = order.getRestaurantId();
+		Restaurant restaurant = restaurantRepository.findById(restaurantId)
+			.orElseThrow(() -> new RestaurantException(ErrorCode.RESTAURANT_NOT_FOUND));
+
+		// 리뷰 생성
+		Review review = Review.builder()
+			.restaurant(restaurant)
+			.userId(currentUserId)
+			.orderId(orderId)
+			.rating(request.getRating())
+			.content(request.getContent())
+			.build();
+		reviewRepository.save(review);
+
+		// 음식점 평점 집계 업데이트
+		Double newRatingSum = restaurant.getRatingSum() + review.getRating();
+		Integer newRatingCount = restaurant.getRatingCount() + 1;
+		restaurant.updateRatingSum(newRatingSum);
+		restaurant.updateRatingCount(newRatingCount);
+		restaurant.updateAvgRating(newRatingSum / newRatingCount);
+
+		return new ReviewResponse.Create(review.getId());
+	}
+
+	// 리뷰 수정
+	public ReviewResponse.Read updateReview(UUID reviewId, UUID currentUserId, ReviewRequest.Update request) {
+		Review review = getReview(reviewId);
+
+		// 리뷰 작성자와 현재 로그인한 사용자가 동일한지 확인
+		if (!review.getUserId().equals(currentUserId)) {
+			throw new ReviewException(ErrorCode.REVIEW_NOT_ALLOWED);
+		}
+
+		Restaurant restaurant = review.getRestaurant();
+		Integer oldRating = review.getRating();
+		Integer newRating = request.getRating();
+
+		review.update(newRating, request.getContent());
+		reviewRepository.save(review);
+
+		// 음식점 평점 집계 업데이트
+		if (newRating != null && !newRating.equals(oldRating)) {
+			Integer diff = review.getRating() - oldRating;
+			Double newRatingSum = restaurant.getRatingSum() + diff;
+			restaurant.updateRatingSum(newRatingSum);
+			restaurant.updateAvgRating(newRatingSum / restaurant.getRatingCount());
+		}
+
+		return ReviewResponse.Read.builder()
+			.id(review.getId())
+			.restaurantId(restaurant.getId())
+			.userId(review.getUserId())
+			.rating(review.getRating())
+			.content(review.getContent())
+			.createdAt(review.getCreatedAt())
+			.updatedAt(review.getUpdatedAt())
+			.build();
+	}
+
+	// 리뷰 삭제
+	public void deleteReview(UUID reviewId, UUID currentUserId, String currentUsername) {
+		Review review = getReview(reviewId);
+
+		// 리뷰 작성자와 현재 로그인한 사용자가 동일한지 확인
+		if (!review.getUserId().equals(currentUserId)) {
+			throw new ReviewException(ErrorCode.REVIEW_NOT_ALLOWED);
+		}
+
+		Restaurant restaurant = review.getRestaurant();
+		review.softDelete(currentUsername);
+
+		// 음식점 평점 집계 업데이트
+		Double newRatingSum = restaurant.getRatingSum() - review.getRating();
+		Integer newRatingCount = restaurant.getRatingCount() - 1;
+		restaurant.updateRatingSum(newRatingSum);
+		restaurant.updateRatingCount(newRatingCount);
+		if (newRatingCount > 0) {
+			restaurant.updateAvgRating(newRatingSum / newRatingCount);
+		} else {
+			restaurant.updateAvgRating(0.0);
+		}
+	}
+
+	private Review getReview(UUID reviewId) {
+		return reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new ReviewException(ErrorCode.REVIEW_NOT_FOUND));
+	}
+
+}

--- a/src/main/java/com/order/orderlink/review/application/ReviewService.java
+++ b/src/main/java/com/order/orderlink/review/application/ReviewService.java
@@ -1,7 +1,10 @@
 package com.order.orderlink.review.application;
 
+import java.util.List;
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -82,6 +85,24 @@ public class ReviewService {
 		restaurant.updateAvgRating(newRatingSum / newRatingCount);
 
 		return new ReviewResponse.Create(review.getId());
+	}
+
+	// 특정 음식점에 대한 모든 리뷰 조회
+	public ReviewResponse.ReadAsPage getReviewsByRestaurant(UUID restaurantId, Pageable pageable) {
+		Page<Review> page = reviewRepository.findByRestaurantId(restaurantId, pageable);
+		List<ReviewResponse.Read> reviews = page.getContent().stream().map(review ->
+				ReviewResponse.Read.builder()
+					.id(review.getId())
+					.restaurantId(review.getRestaurant().getId())
+					.userId(review.getUserId())
+					.rating(review.getRating())
+					.content(review.getContent())
+					.createdAt(review.getCreatedAt())
+					.updatedAt(review.getUpdatedAt())
+					.build())
+			.toList();
+		return new ReviewResponse.ReadAsPage(reviews, page.getNumber() + 1, page.getTotalPages(),
+			page.getTotalElements());
 	}
 
 	// 리뷰 수정

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewRequest.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewRequest.java
@@ -1,0 +1,37 @@
+package com.order.orderlink.review.application.dtos;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.Setter;
+
+public class ReviewRequest {
+
+	@Getter
+	@Setter
+	public static class Create {
+
+		@NotNull(message = "평점은 필수입니다.")
+		@Min(value = 1, message = "평점은 최소 1점이어야 합니다.")
+		@Max(value = 5, message = "평점은 최대 5점이어야 합니다.")
+		private Integer rating;
+
+		@Size(max = 500, message = "리뷰는 최대 500자까지 입력 가능합니다.")
+		private String content;
+	}
+
+	@Getter
+	@Setter
+	public static class Update {
+
+		@Min(value = 1, message = "평점은 최소 1점이어야 합니다.")
+		@Max(value = 5, message = "평점은 최대 5점이어야 합니다.")
+		private Integer rating;
+
+		private String content;
+
+	}
+
+}

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewRequest.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewRequest.java
@@ -30,6 +30,7 @@ public class ReviewRequest {
 		@Max(value = 5, message = "평점은 최대 5점이어야 합니다.")
 		private Integer rating;
 
+		@Size(max = 500, message = "리뷰는 최대 500자까지 입력 가능합니다.")
 		private String content;
 
 	}

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
@@ -1,6 +1,7 @@
 package com.order.orderlink.review.application.dtos;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 
 import lombok.AllArgsConstructor;
@@ -27,6 +28,16 @@ public class ReviewResponse {
 		private String content;
 		private LocalDateTime createdAt;
 		private LocalDateTime updatedAt;
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class ReadAsPage {
+		private List<ReviewResponse.Read> reviews;
+		private Integer currentPage;
+		private Integer totalPages;
+		private Long totalElements;
 	}
 
 }

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
@@ -14,14 +14,14 @@ public class ReviewResponse {
 	@Builder
 	@AllArgsConstructor
 	public static class Create {
-		private UUID id;
+		private UUID reviewId;
 	}
 
 	@Getter
 	@Builder
 	@AllArgsConstructor
-	public static class Read {
-		private UUID id;
+	public static class Update {
+		private UUID reviewId;
 		private UUID restaurantId;
 		private UUID userId;
 		private Integer rating;
@@ -33,11 +33,46 @@ public class ReviewResponse {
 	@Getter
 	@Builder
 	@AllArgsConstructor
-	public static class ReadAsPage {
-		private List<ReviewResponse.Read> reviews;
-		private Integer currentPage;
+	public static class ReviewPageResponse {
+		private List<ReviewResponse.Summary> reviews;
+		private Integer currentPage; // 1-based
 		private Integer totalPages;
 		private Long totalElements;
+	}
+
+	// 리뷰 목록 조회 응답 DTO (간략한 정보)
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class Summary {
+		private UUID reviewId;
+		private String userNickname; // 리뷰 작성자의 닉네임
+		private Integer rating;
+		private String contentSummary; // 리뷰 내용의 일부 (50자 이내 요약)
+		private LocalDateTime createdAt;
+	}
+
+	// 리뷰 상세 조회 응답 DTO (자세한 정보)
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class Detail {
+		private UUID reviewId;
+		private String userNickname;
+		private Integer rating;
+		private String fullContentText; // 리뷰 내용 전체
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
+		private OrderDetails orderDetails;
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class OrderDetails {
+		private UUID orderId;
+		private LocalDateTime orderDate;
+		private List<String> orderItems;
 	}
 
 }

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
@@ -1,0 +1,32 @@
+package com.order.orderlink.review.application.dtos;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+public class ReviewResponse {
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class Create {
+		private UUID id;
+	}
+
+	@Getter
+	@Builder
+	@AllArgsConstructor
+	public static class Read {
+		private UUID id;
+		private UUID restaurantId;
+		private UUID userId;
+		private Integer rating;
+		private String content;
+		private LocalDateTime createdAt;
+		private LocalDateTime updatedAt;
+	}
+
+}

--- a/src/main/java/com/order/orderlink/review/domain/Review.java
+++ b/src/main/java/com/order/orderlink/review/domain/Review.java
@@ -1,0 +1,78 @@
+package com.order.orderlink.review.domain;
+
+import java.util.UUID;
+
+import org.hibernate.annotations.SQLRestriction;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import com.order.orderlink.common.entity.BaseTimeEntity;
+import com.order.orderlink.restaurant.domain.Restaurant;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@Table(name = "p_reviews")
+@SQLRestriction("deleted_at IS NULL")
+@EntityListeners(AuditingEntityListener.class)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseTimeEntity {
+
+	@Id
+	@GeneratedValue
+	@UuidGenerator(style = UuidGenerator.Style.AUTO)
+	@Column(name = "id", updatable = false, nullable = false)
+	private UUID id;
+
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "restaurant_id", nullable = false)
+	private Restaurant restaurant;
+
+	@Column(name = "user_id", nullable = false)
+	private UUID userId;
+
+	@Column(name = "order_id", nullable = false, unique = true)
+	private UUID orderId;
+
+	@Column(name = "rating", nullable = false)
+	private Integer rating;
+
+	@Column(name = "content", columnDefinition = "TEXT")
+	private String content;
+
+	@Builder
+	public Review(Restaurant restaurant, UUID userId, UUID orderId, Integer rating, String content) {
+		this.restaurant = restaurant;
+		this.userId = userId;
+		this.orderId = orderId;
+		this.rating = rating;
+		this.content = content;
+	}
+
+	public void update(Integer newRating, String newContent) {
+		if (newRating != null) {
+			this.rating = newRating;
+		}
+		if (newContent != null && !newContent.trim().isEmpty()) {
+			this.content = newContent;
+		}
+	}
+
+	public void softDelete(String deletedBy) {
+		super.softDelete(deletedBy);
+	}
+
+}

--- a/src/main/java/com/order/orderlink/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/order/orderlink/review/domain/repository/ReviewRepository.java
@@ -2,6 +2,8 @@ package com.order.orderlink.review.domain.repository;
 
 import java.util.UUID;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.order.orderlink.review.domain.Review;
@@ -9,5 +11,7 @@ import com.order.orderlink.review.domain.Review;
 public interface ReviewRepository extends JpaRepository<Review, UUID> {
 
 	boolean existsByOrderId(UUID orderId);
+
+	Page<Review> findByRestaurantId(UUID restaurantId, Pageable pageable);
 
 }

--- a/src/main/java/com/order/orderlink/review/domain/repository/ReviewRepository.java
+++ b/src/main/java/com/order/orderlink/review/domain/repository/ReviewRepository.java
@@ -1,0 +1,13 @@
+package com.order.orderlink.review.domain.repository;
+
+import java.util.UUID;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.order.orderlink.review.domain.Review;
+
+public interface ReviewRepository extends JpaRepository<Review, UUID> {
+
+	boolean existsByOrderId(UUID orderId);
+
+}

--- a/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
+++ b/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
@@ -50,9 +50,9 @@ public class ReviewController {
 	 * @see ReviewService#createReview(UUID, UUID, ReviewRequest.Create)
 	 * @author Jihwan
 	 */
-	@PostMapping("/orders/{orderId}")
+	@PostMapping
 	@PreAuthorize("hasAuthority('ROLE_CUSTOMER')")
-	public SuccessResponse<ReviewResponse.Create> createReview(@PathVariable("orderId") String orderIdStr,
+	public SuccessResponse<ReviewResponse.Create> createReview(@RequestParam("orderId") String orderIdStr,
 		@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody ReviewRequest.Create request) {
 
 		UUID orderId = UUID.fromString(orderIdStr);

--- a/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
+++ b/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
@@ -1,0 +1,96 @@
+package com.order.orderlink.review.presentation;
+
+import java.util.UUID;
+
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.order.orderlink.common.auth.UserDetailsImpl;
+import com.order.orderlink.common.dtos.SuccessNonDataResponse;
+import com.order.orderlink.common.dtos.SuccessResponse;
+import com.order.orderlink.common.enums.SuccessCode;
+import com.order.orderlink.common.exception.OrderException;
+import com.order.orderlink.common.exception.RestaurantException;
+import com.order.orderlink.common.exception.ReviewException;
+import com.order.orderlink.review.application.ReviewService;
+import com.order.orderlink.review.application.dtos.ReviewRequest;
+import com.order.orderlink.review.application.dtos.ReviewResponse;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/reviews")
+@RequiredArgsConstructor
+public class ReviewController {
+
+	private final ReviewService reviewService;
+
+	/**
+	 * 리뷰 등록
+	 * @param orderIdStr 주문 ID
+	 * @param userDetails 로그인한 사용자 정보
+	 * @param request 리뷰 생성 요청 정보 (평점, 내용)
+	 * @return 생성된 리뷰 ID
+	 * @throws OrderException 주문이 존재하지 않는 경우
+	 * @throws ReviewException 리뷰 작성이 허용되지 않는 경우, 이미 리뷰가 작성된 경우
+	 * @throws RestaurantException 음식점이 존재하지 않는 경우
+	 * @see ReviewService#createReview(UUID, UUID, ReviewRequest.Create)
+	 * @author Jihwan
+	 */
+	@PostMapping("/orders/{orderId}")
+	@PreAuthorize("hasAuthority('ROLE_CUSTOMER')")
+	public SuccessResponse<ReviewResponse.Create> createReview(@PathVariable("orderId") String orderIdStr,
+		@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody ReviewRequest.Create request) {
+
+		UUID orderId = UUID.fromString(orderIdStr);
+		UUID userId = userDetails.getUser().getId();
+
+		return SuccessResponse.success(SuccessCode.REVIEW_CREATE_SUCCESS,
+			reviewService.createReview(orderId, userId, request));
+	}
+
+	/**
+	 * 리뷰 수정
+	 * @param reviewId 리뷰 ID
+	 * @param userDetails 로그인한 사용자 정보
+	 * @param request 리뷰 수정 요청 정보 (평점, 내용)
+	 * @return 수정된 리뷰 정보 (리뷰 ID, 음식점 ID, 사용자 ID, 평점, 내용, 생성일, 수정일)
+	 * @throws ReviewException 리뷰 수정이 허용되지 않는 경우
+	 * @author Jihwan
+	 */
+	@PutMapping("/{reviewId}")
+	@PreAuthorize("hasAuthority('ROLE_CUSTOMER')")
+	public SuccessResponse<ReviewResponse.Read> updateReview(@PathVariable("reviewId") UUID reviewId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody ReviewRequest.Update request) {
+		UUID userId = userDetails.getUser().getId();
+		return SuccessResponse.success(SuccessCode.REVIEW_UPDATE_SUCCESS,
+			reviewService.updateReview(reviewId, userId, request));
+	}
+
+	/**
+	 * 리뷰 삭제
+	 * @param reviewId 리뷰 ID
+	 * @param userDetails 로그인한 사용자 정보
+	 * @return 성공 응답 (성공 코드)
+	 * @throws ReviewException 리뷰 삭제가 허용되지 않는 경우
+	 * @author Jihwan
+	 */
+	@DeleteMapping("/{reviewId}")
+	@PreAuthorize("hasAuthority('ROLE_CUSTOMER')")
+	public SuccessNonDataResponse deleteReview(@PathVariable("reviewId") UUID reviewId,
+		@AuthenticationPrincipal UserDetailsImpl userDetails) {
+		UUID userId = userDetails.getUser().getId();
+		String username = userDetails.getUser().getUsername();
+		reviewService.deleteReview(reviewId, userId, username);
+		return SuccessNonDataResponse.success(SuccessCode.REVIEW_DELETE_SUCCESS);
+	}
+
+}

--- a/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
+++ b/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
@@ -28,7 +28,6 @@ import com.order.orderlink.review.application.ReviewService;
 import com.order.orderlink.review.application.dtos.ReviewRequest;
 import com.order.orderlink.review.application.dtos.ReviewResponse;
 
-import jakarta.annotation.security.PermitAll;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
@@ -70,16 +69,13 @@ public class ReviewController {
 	 * @param size 페이지 크기
 	 * @param sort 정렬 조건 (필드명, 정렬 방향)
 	 * @return 페이징 처리된 리뷰 목록 (리뷰 ID, 음식점 ID, 사용자 ID, 평점, 내용, 생성일, 수정일)
-	 * @see ReviewResponse.ReadAsPage
+	 * @see ReviewResponse.ReviewPageResponse
 	 * @author Jihwan
 	 */
 	@GetMapping
-	@PermitAll
-	public SuccessResponse<ReviewResponse.ReadAsPage> getReviewsByRestaurant(
-		@RequestParam("restaurantId") UUID restaurantId,
-		@RequestParam(defaultValue = "1") int page,
-		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(required = false) String sort) {
+	public SuccessResponse<ReviewResponse.ReviewPageResponse> getReviewsByRestaurant(
+		@RequestParam("restaurantId") UUID restaurantId, @RequestParam(defaultValue = "1") int page,
+		@RequestParam(defaultValue = "10") int size, @RequestParam(required = false) String sort) {
 
 		// 페이지 번호가 1보다 작으면 1로 설정
 		if (page < 1) {
@@ -133,6 +129,18 @@ public class ReviewController {
 	}
 
 	/**
+	 * 리뷰 상세 조회
+	 * @param reviewId 리뷰 ID
+	 * @return 리뷰 상세 정보 (리뷰 ID, 사용자 닉네임, 평점, 내용, 생성일, 수정일)
+	 * @see ReviewResponse.Detail
+	 * @author Jihwan
+	 */
+	@GetMapping("/{reviewId}")
+	public SuccessResponse<ReviewResponse.Detail> getReviewDetail(@PathVariable("reviewId") UUID reviewId) {
+		return SuccessResponse.success(SuccessCode.REVIEW_GET_DETAIL_SUCCESS, reviewService.getReviewDetail(reviewId));
+	}
+
+	/**
 	 * 리뷰 수정
 	 * @param reviewId 리뷰 ID
 	 * @param userDetails 로그인한 사용자 정보
@@ -143,7 +151,7 @@ public class ReviewController {
 	 */
 	@PutMapping("/{reviewId}")
 	@PreAuthorize("hasAuthority('ROLE_CUSTOMER')")
-	public SuccessResponse<ReviewResponse.Read> updateReview(@PathVariable("reviewId") UUID reviewId,
+	public SuccessResponse<ReviewResponse.Update> updateReview(@PathVariable("reviewId") UUID reviewId,
 		@AuthenticationPrincipal UserDetailsImpl userDetails, @Valid @RequestBody ReviewRequest.Update request) {
 		UUID userId = userDetails.getUser().getId();
 		return SuccessResponse.success(SuccessCode.REVIEW_UPDATE_SUCCESS,

--- a/src/main/java/com/order/orderlink/user/presentation/UserController.java
+++ b/src/main/java/com/order/orderlink/user/presentation/UserController.java
@@ -96,7 +96,7 @@ public class UserController {
 
 		// 1-based로 받은 페이지 번호를 0-based 페이지 번호로 변환
 		Pageable pageable = PageRequest.of(page - 1, size, sortObj);
-		return SuccessResponse.success(SuccessCode.USER_READ_ALL_SUCCESS, userService.getAllUsers(pageable));
+		return SuccessResponse.success(SuccessCode.USER_GET_SUCCESS, userService.getAllUsers(pageable));
 	}
 
 	/**
@@ -109,7 +109,7 @@ public class UserController {
 	@GetMapping("/me")
 	public SuccessResponse<UserResponse.Read> getMyInfo(@AuthenticationPrincipal UserDetailsImpl userDetails) {
 		UUID userId = userDetails.getUser().getId();
-		return SuccessResponse.success(SuccessCode.USER_READ_SUCCESS, userService.getMyInfo(userId));
+		return SuccessResponse.success(SuccessCode.USER_GET_DETAIL_SUCCESS, userService.getMyInfo(userId));
 	}
 
 	/**
@@ -122,7 +122,7 @@ public class UserController {
 	@GetMapping("/{id}")
 	@PreAuthorize("hasAuthority('ROLE_MASTER')")
 	public SuccessResponse<UserResponse.Read> getUserInfoByAdmin(@PathVariable("id") UUID userId) {
-		return SuccessResponse.success(SuccessCode.USER_READ_SUCCESS, userService.getUserInfoByAdmin(userId));
+		return SuccessResponse.success(SuccessCode.USER_GET_DETAIL_SUCCESS, userService.getUserInfoByAdmin(userId));
 	}
 
 	/**

--- a/src/main/java/com/order/orderlink/user/presentation/UserController.java
+++ b/src/main/java/com/order/orderlink/user/presentation/UserController.java
@@ -63,7 +63,7 @@ public class UserController {
 	public SuccessResponse<UserResponse.ReadUserList> getAllUsers(
 		@RequestParam(defaultValue = "1") int page,
 		@RequestParam(defaultValue = "10") int size,
-		@RequestParam(defaultValue = "createdAt,asc") String sort) {
+		@RequestParam(required = false) String sort) {
 
 		if (page < 1) {
 			page = 1;
@@ -80,14 +80,30 @@ public class UserController {
 			if (sortParts.length == 2) {
 				String fieldInput = sortParts[0].trim();
 				String orderInput = sortParts[1].trim().toLowerCase();
-
-				if (!fieldInput.isEmpty() && (orderInput.equals("asc") || orderInput.equals("desc"))) {
-					sortObj = orderInput.equals("asc") ?
-						Sort.by(fieldInput).ascending() : Sort.by(fieldInput).descending();
+				// field가 "id", "username", "email", "phone", "nickname", "createdAt", "updatedAt' 중 하나이면 사용,
+				// 아니면 기본 정렬 적용
+				if (fieldInput.equals("id") || fieldInput.equals("username") || fieldInput.equals("email")
+					|| fieldInput.equals("phone") || fieldInput.equals("nickname") || fieldInput.equals("createdAt")
+					|| fieldInput.equals("updatedAt")) {
+					if (orderInput.equals("asc")) {
+						sortObj = Sort.by(fieldInput).ascending();
+					} else if (orderInput.equals("desc")) {
+						sortObj = Sort.by(fieldInput).descending();
+					}
+				} else {
+					// 유효하지 않은 field이면 기본값 적용
+					sortObj = Sort.by(
+						Sort.Order.desc("createdAt"),
+						Sort.Order.desc("updatedAt")
+					);
 				}
+			} else {
+				sortObj = Sort.by(
+					Sort.Order.desc("createdAt"),
+					Sort.Order.desc("updatedAt")
+				);
 			}
-		}
-		if (sortObj == null) {
+		} else {
 			sortObj = Sort.by(
 				Sort.Order.desc("createdAt"),
 				Sort.Order.desc("updatedAt")
@@ -95,6 +111,7 @@ public class UserController {
 		}
 
 		// 1-based로 받은 페이지 번호를 0-based 페이지 번호로 변환
+		assert sortObj != null;
 		Pageable pageable = PageRequest.of(page - 1, size, sortObj);
 		return SuccessResponse.success(SuccessCode.USER_GET_SUCCESS, userService.getAllUsers(pageable));
 	}


### PR DESCRIPTION
* 주문자만 리뷰를 작성할 수 있으며, 한 주문당 한 개의 리뷰만 작성 가능
* 리뷰는 해당 주문을 한 음식점에 대해서 리뷰를 작성
* 주문에 대한 리뷰가 이미 존재하면 예외 발생
* 주문의 userId와 로그인한 사용자가 동일한 경우에만 작성 가능. 그렇지 않으면 해당 리뷰에 대한 권한이 없다는 예외 발생
* 리뷰 등록/수정/삭제시마다 음식점 테이블의 중간 집계 필드들(avgRating, ratingSum, ratingCount)도 업데이트
* 특정 음식점에 대한 리뷰 목록 조회시에는 요약본이 보여지게 되며, 리뷰 내용이 50자가 넘는 경우에는 "..." 으로 뒷 부분이 잘리게 표현
* 리뷰 목록 조회에서는 간략한 정보를 제공하고, 상세 조회에서는 주문 관련 정보까지 자세한 정보를 추가로 제공

> 로컬에서 전부 테스트 마쳤습니다.
> 권한 설정도 잘 되어있고, 등록/수정/삭제 정상적으로 동작합니다.
> 또한 음식점 테이블의 중간 집계 필드 역시 잘 업데이트 됩니다.

`1. 리뷰 등록`
<img width="494" alt="image" src="https://github.com/user-attachments/assets/d970cd07-b535-4389-b252-ecdfb906a57b" />
`2. 리뷰 목록 조회`
<img width="805" alt="image" src="https://github.com/user-attachments/assets/1003ca4a-5349-40a8-98ab-02d6058a7c34" />
`3. 리뷰 상세 조회`
<img width="1301" alt="image" src="https://github.com/user-attachments/assets/6eee8145-f1b3-4728-9237-bf400eb7713a" />
`4. 리뷰 수정`
<img width="1339" alt="image" src="https://github.com/user-attachments/assets/f8807fab-cea9-4648-b1df-2ca1bbfc0944" />
`5. 리뷰 삭제`
<img width="373" alt="image" src="https://github.com/user-attachments/assets/4e728d23-7856-4ad0-b5f3-11d773ac12f5" />
`6. 예외 처리 예시`
<img width="387" alt="image" src="https://github.com/user-attachments/assets/02bbac32-77a0-4fb1-9f1f-4e7d8ff2ddb8" />
<img width="373" alt="image" src="https://github.com/user-attachments/assets/589987c1-3b2f-47a5-9cce-462d912f7841" />