### PR TITLE
[Refactor] 보안되지 않은 API에서 보안되어 있는 API 호출이 가능하도록 인가 관련 로직 추가

### DIFF
--- a/src/main/java/com/order/orderlink/common/auth/ServiceAccountUserDetails.java
+++ b/src/main/java/com/order/orderlink/common/auth/ServiceAccountUserDetails.java
@@ -1,0 +1,26 @@
+package com.order.orderlink.common.auth;
+
+import java.util.Collection;
+import java.util.Collections;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+public class ServiceAccountUserDetails implements UserDetails {
+
+	@Override
+	public Collection<? extends GrantedAuthority> getAuthorities() {
+		return Collections.singletonList(new SimpleGrantedAuthority("ROLE_SERVICE_ACCOUNT"));
+	}
+
+	@Override
+	public String getPassword() {
+		return "";
+	}
+
+	@Override
+	public String getUsername() {
+		return "serviceAccount";
+	}
+}

--- a/src/main/java/com/order/orderlink/common/auth/controller/ServiceAccountTokenController.java
+++ b/src/main/java/com/order/orderlink/common/auth/controller/ServiceAccountTokenController.java
@@ -1,0 +1,87 @@
+package com.order.orderlink.common.auth.controller;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.crypto.SecretKey;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j(topic = "service-account-token-controller")
+@RestController
+@RequestMapping("/api/oauth")
+public class ServiceAccountTokenController {
+
+	@Value("${service.account.client-id}")
+	private String validClientId;
+
+	@Value("${service.account.client-secret}")
+	private String validClientSecret;
+
+	@Value("${spring.application.name}")
+	private String issuer;
+
+	@Value("${jwt.secret.key}")
+	private String jwtSecretKey;
+
+	// client_credentials 방식 토큰 발급
+	@PostMapping(value = "/token", consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+	public Map<String, Object> getToken(@RequestParam MultiValueMap<String, String> formData) {
+		String grantType = formData.getFirst("grant_type");
+		String clientId = formData.getFirst("client_id");
+		String clientSecret = formData.getFirst("client_secret");
+
+		Map<String, Object> response = new HashMap<>();
+
+		// grantType 이 client_credential 인지 검증
+		if (!"client_credentials".equals(grantType)) {
+			response.put("error", "unsupported_grant_type");
+			response.put("error_description", "Only client_credentials grant type is supported.");
+			return response;
+		}
+
+		// clientId 와 clientSecret 검증
+		if (!validClientId.equals(clientId) || !validClientSecret.equals(clientSecret)) {
+			response.put("error", "invalid_client");
+			response.put("error_description", "Client authentication failed.");
+			return response;
+		}
+
+		// JWT 토큰 생성
+		Date now = new Date();
+		Date expiry = new Date(now.getTime() + 3600 * 1000L); // 1시간 유효
+
+		SecretKey key = Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(jwtSecretKey));
+
+		String jwtToken = "Bearer " + Jwts.builder()
+			.header().add("typ", "JWT").and()
+			.subject("serviceAccount")
+			.claim("auth", "ROLE_SERVICE_ACCOUNT")
+			.claim("userId", "serviceAccount")
+			.issuer(issuer)
+			.issuedAt(now)
+			.expiration(expiry)
+			.signWith(key, Jwts.SIG.HS512)
+			.compact();
+
+		response.put("access_token", jwtToken);
+		response.put("token_type", "Bearer");
+		response.put("expires_in", 3600);
+		response.put("scope", "read write");
+		response.put("issued_at", now.toString());
+		return response;
+	}
+
+}

--- a/src/main/java/com/order/orderlink/common/auth/service/ServiceAccountTokenService.java
+++ b/src/main/java/com/order/orderlink/common/auth/service/ServiceAccountTokenService.java
@@ -1,0 +1,82 @@
+package com.order.orderlink.common.auth.service;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import com.order.orderlink.common.enums.ErrorCode;
+import com.order.orderlink.common.exception.AuthException;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.slf4j.Slf4j;
+import reactor.core.publisher.Mono;
+
+@Slf4j(topic = "service-account-token-service")
+@Service
+public class ServiceAccountTokenService {
+
+	@Value("${service.account.client-id}")
+	private String clientId;
+
+	@Value("${service.account.client-secret}")
+	private String clientSecret;
+
+	@Value("${service.account.token-uri}")
+	private String tokenUri;
+
+	private String cachedToken;
+	private long tokenExpiryTime; // milliseconds
+
+	public synchronized String getAccessToken() {
+		// 캐시된 토큰이 없거나 만료되기 30초 전에 새 토큰을 요청 (갱신)
+		if (cachedToken == null || System.currentTimeMillis() > (tokenExpiryTime - 30000)) {
+			try {
+				MultiValueMap<String, String> formData = new LinkedMultiValueMap<>();
+				formData.add("grant_type", "client_credentials");
+				formData.add("client_id", clientId);
+				formData.add("client_secret", clientSecret);
+
+				WebClient internalWebClient = WebClient.create(tokenUri);
+				Mono<TokenResponse> tokenResponseMono = internalWebClient.post()
+					.uri("")
+					.contentType(MediaType.APPLICATION_FORM_URLENCODED)
+					.body(BodyInserters.fromFormData(formData))
+					.retrieve()
+					.bodyToMono(TokenResponse.class);
+
+				TokenResponse tokenResponse = tokenResponseMono.block();
+				if (tokenResponse != null) {
+					cachedToken = tokenResponse.getAccessToken();
+					tokenExpiryTime = System.currentTimeMillis() + tokenResponse.getExpiresIn() * 1000L;
+				} else {
+					throw new AuthException(ErrorCode.FAILED_TO_GET_SERVICE_ACCOUNT_TOKEN);
+				}
+			} catch (Exception e) {
+				log.error("토큰 발급 실패: {}", e.getMessage(), e);
+				throw new AuthException(ErrorCode.FAILED_TO_GET_SERVICE_ACCOUNT_TOKEN);
+			}
+		}
+		return cachedToken;
+	}
+
+	@Getter
+	@Setter
+	public static class TokenResponse {
+		private String access_token;
+		private int expires_in;
+
+		public String getAccessToken() {
+			return access_token;
+		}
+
+		public int getExpiresIn() {
+			return expires_in;
+		}
+	}
+
+}

--- a/src/main/java/com/order/orderlink/common/client/OrderClient.java
+++ b/src/main/java/com/order/orderlink/common/client/OrderClient.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.order.orderlink.common.auth.service.ServiceAccountTokenService;
 import com.order.orderlink.order.domain.Order;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,8 @@ import lombok.RequiredArgsConstructor;
 public class OrderClient {
 
 	private final WebClient webClient;
+	private final ServiceAccountTokenService tokenService;
+
 	private static final String ORDERS_URL = "/orders";
 
 	public Order getOrder(UUID orderId, String accessToken) {
@@ -23,6 +26,21 @@ public class OrderClient {
 			.retrieve()
 			.bodyToMono(Order.class)
 			.block();
+	}
+
+	// 인증이 되지 않은 상태에서 내부 서비스 호출을 위한 메서드
+	public Order getOrder(UUID orderId) {
+		String accessToken = getAccessTokenForInternalCall();
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder.path(ORDERS_URL + "/{orderId}/getOrder").build(orderId))
+			.header("Authorization", accessToken)
+			.retrieve()
+			.bodyToMono(Order.class)
+			.block();
+	}
+
+	private String getAccessTokenForInternalCall() {
+		return tokenService.getAccessToken();
 	}
 
 }

--- a/src/main/java/com/order/orderlink/common/client/UserClient.java
+++ b/src/main/java/com/order/orderlink/common/client/UserClient.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
+import com.order.orderlink.common.auth.service.ServiceAccountTokenService;
 import com.order.orderlink.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 public class UserClient {
 
 	private final WebClient webClient;
+	private final ServiceAccountTokenService tokenService;
 
 	private static final String USERS_URL = "/users";
 
@@ -25,4 +27,20 @@ public class UserClient {
 			.bodyToMono(User.class)
 			.block();
 	}
+
+	// 인증이 되지 않은 상태에서 내부 서비스 호출을 위한 메서드
+	public User getUser(UUID userId) {
+		String accessToken = getAccessTokenForInternalCall();
+		return webClient.get()
+			.uri(uriBuilder -> uriBuilder.path(USERS_URL + "/{userId}/getUser").build(userId))
+			.header("Authorization", accessToken)
+			.retrieve()
+			.bodyToMono(User.class)
+			.block();
+	}
+
+	private String getAccessTokenForInternalCall() {
+		return tokenService.getAccessToken();
+	}
+
 }

--- a/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
+++ b/src/main/java/com/order/orderlink/common/config/SecurityConfig.java
@@ -77,6 +77,7 @@ public class SecurityConfig {
 				.requestMatchers(HttpMethod.PUT, "/api/restaurants/**").hasAuthority("ROLE_MASTER")
 				.requestMatchers(HttpMethod.DELETE, "/api/restaurants/**").hasAuthority("ROLE_MASTER")
 				.requestMatchers(HttpMethod.GET, "/api/reviews/**").permitAll()
+				.requestMatchers(HttpMethod.POST, "/api/oauth/token").permitAll()
 				.anyRequest().authenticated()
 			);
 

--- a/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/ErrorCode.java
@@ -9,6 +9,7 @@ public enum ErrorCode {
 
 	// AUTH
 	TOKEN_INVALID(HttpStatus.UNAUTHORIZED, "토큰이 유효하지 않습니다."),
+	FAILED_TO_GET_SERVICE_ACCOUNT_TOKEN(HttpStatus.INTERNAL_SERVER_ERROR, "서비스 계정 토큰을 가져오는데 실패했습니다."),
 
 	// USER
 	USER_ALREADY_EXISTS(HttpStatus.BAD_REQUEST, "이미 존재하는 사용자입니다."),

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -28,3 +28,7 @@ cloud.aws.credentials.accesskey=${AWS_ACCESS_KEY}
 cloud.aws.credentials.secretkey=${AWS_SECRET_ACCESS_KEY}
 cloud.aws.region.static=ap-northeast-2
 cloud.aws.s3.bucket=orderlinkbucket
+# service account
+service.account.client-id=${SERVICE_ACCOUNT_ID}
+service.account.client-secret=${SERVICE_ACCOUNT_SECRET}
+service.account.token-uri=http://localhost:8080/api/oauth/token


### PR DESCRIPTION
- [x] 다른 도메인을 repository를 통해 직접 접근하지 않고 webClient를 사용하여 접근하도록 변경


- 대략적인 흐름은 아래와 같습니다.
1. 내부 서비스 호출을 위한 가상의 serviceAccount라는 이름의 subject 생성
2. 보안되지 않은 API에서 보안되어 있는 API를 내부적으로 호출
3. serviceAccount라는 이름으로 서비스 계정용(내부 호출용) 토큰을 발급받아 webClient에 전달
5. 명시적으로 accessToken을 넘겨주지 않아도 내부적으로 생성된 토큰이 헤더에 담겨져서 요청이 보내짐

> `하,,, 참 끝내고 이렇게 정리해보니 별거 아닌거 같은데, 하면서 오류를 너무 많이 맞닥뜨려서 해결하느라 좀 지체됐습니다 ㅜㅜ 그래도 얼떨결에 공부 한번 제대로 했네요 ㅎㅎ 다른 도메인에서도 인증되어 있지 않은 상태에서 보안 API 접근할 때 사용 가능합니다! 그리고 환경변수 2개 추가됐습니다!`