### PR TITLE
[Feat] 특정 카테고리가 적용된 음식점 목록 조회 API 기능 구현

### DIFF
--- a/src/main/java/com/order/orderlink/category/application/CategoryService.java
+++ b/src/main/java/com/order/orderlink/category/application/CategoryService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
+import com.order.orderlink.common.client.RestaurantClient;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -25,6 +26,7 @@ import lombok.RequiredArgsConstructor;
 public class CategoryService {
 	private final CategoryRepository categoryRepository;
 	private final RestaurantCategoryRepository restaurantCategoryRepository;
+	private final RestaurantClient restaurantClient;
 
 	public CategoryResponse.Create createCategory(CategoryRequest.Create request) {
 		Category category = Category.builder()
@@ -39,8 +41,8 @@ public class CategoryService {
 		for (UUID categoryId : categoryIds) {
 			Category category = getCategory(categoryId);
 			RestaurantCategory restaurantCategory = RestaurantCategory.builder()
-				.categoryId(category.getId())
-				.restaurantId(restaurantId)
+				.category(category)
+				.restaurant(restaurantClient.getRestaurant(restaurantId))
 				.build();
 			restaurantCategoryRepository.save(restaurantCategory);
 		}

--- a/src/main/java/com/order/orderlink/category/domain/Category.java
+++ b/src/main/java/com/order/orderlink/category/domain/Category.java
@@ -37,7 +37,7 @@ public class Category extends BaseTimeEntity {
 	@NotNull
 	private String name;
 
-	@OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+	@OneToMany(mappedBy = "category", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
 	private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
 
 	public void updateName(String name) {

--- a/src/main/java/com/order/orderlink/category/domain/RestaurantCategory.java
+++ b/src/main/java/com/order/orderlink/category/domain/RestaurantCategory.java
@@ -2,15 +2,12 @@ package com.order.orderlink.category.domain;
 
 import java.util.UUID;
 
+import jakarta.persistence.*;
 import org.hibernate.annotations.UuidGenerator;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.order.orderlink.common.entity.BaseTimeEntity;
 
-import jakarta.persistence.Entity;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.Id;
-import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Builder;

--- a/src/main/java/com/order/orderlink/category/domain/RestaurantCategory.java
+++ b/src/main/java/com/order/orderlink/category/domain/RestaurantCategory.java
@@ -1,18 +1,16 @@
 package com.order.orderlink.category.domain;
 
-import java.util.UUID;
-
-import jakarta.persistence.*;
-import org.hibernate.annotations.UuidGenerator;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
 import com.order.orderlink.common.entity.BaseTimeEntity;
-
-import jakarta.validation.constraints.NotNull;
+import com.order.orderlink.restaurant.domain.Restaurant;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.util.UUID;
 
 @Getter
 @NoArgsConstructor
@@ -26,10 +24,12 @@ public class RestaurantCategory extends BaseTimeEntity {
 	@UuidGenerator(style = UuidGenerator.Style.AUTO)
 	private UUID id;
 
-	@NotNull
-	private UUID restaurantId;
+	@ManyToOne
+	@JoinColumn(name = "restaurant_id", nullable = false)
+	private Restaurant restaurant;
 
-	@NotNull
-	private UUID categoryId;
+	@ManyToOne
+	@JoinColumn(name = "category_id", nullable = false)
+	private Category category;
 
 }

--- a/src/main/java/com/order/orderlink/category/domain/repository/RestaurantCategoryRepository.java
+++ b/src/main/java/com/order/orderlink/category/domain/repository/RestaurantCategoryRepository.java
@@ -1,11 +1,13 @@
 package com.order.orderlink.category.domain.repository;
 
-import java.util.UUID;
-
+import com.order.orderlink.category.domain.RestaurantCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.order.orderlink.category.domain.RestaurantCategory;
+import java.util.List;
+import java.util.UUID;
 
 public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCategory, UUID> {
 	void deleteByCategoryId(UUID categoryId);
+
+	List<RestaurantCategory> findAllByCategoryId(UUID categoryId);
 }

--- a/src/main/java/com/order/orderlink/category/domain/repository/RestaurantCategoryRepository.java
+++ b/src/main/java/com/order/orderlink/category/domain/repository/RestaurantCategoryRepository.java
@@ -1,6 +1,7 @@
 package com.order.orderlink.category.domain.repository;
 
 import com.order.orderlink.category.domain.RestaurantCategory;
+import com.order.orderlink.restaurant.domain.Restaurant;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -9,5 +10,5 @@ import java.util.UUID;
 public interface RestaurantCategoryRepository extends JpaRepository<RestaurantCategory, UUID> {
 	void deleteByCategoryId(UUID categoryId);
 
-	List<RestaurantCategory> findAllByCategoryId(UUID categoryId);
+	List<RestaurantCategory> findByCategoryId(UUID categoryId);	List<RestaurantCategory> findAllByCategoryId(UUID categoryId);
 }

--- a/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
+++ b/src/main/java/com/order/orderlink/common/enums/SuccessCode.java
@@ -56,6 +56,7 @@ public enum SuccessCode {
 	// RESTAURANT
 	RESTAURANT_CREATE_SUCCESS(HttpStatus.OK, "음식점 등록 성공입니다."),
 	RESTAURANTS_GET_SUCCESS(HttpStatus.OK, "전체 음식점 조회 성공입니다."),
+	RESTAURANTS_CATEGORY_GET_SUCCESS(HttpStatus.OK, "해당 카테고리의 음식점 리스트 조회 성공입니다."),
 	RESTAURANT_GET_SUCCESS(HttpStatus.OK, "음식점 조회 성공입니다."),
     RESTAURANT_UPDATE_SUCCESS(HttpStatus.OK, "음식점 수정 성공입니다."),
 	RESTAURANT_DELETE_SUCCESS(HttpStatus.OK, "음식점 삭제 성공입니다."),

--- a/src/main/java/com/order/orderlink/restaurant/application/RestaurantService.java
+++ b/src/main/java/com/order/orderlink/restaurant/application/RestaurantService.java
@@ -36,7 +36,7 @@ public class RestaurantService {
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
 
     // 음식점 등록 API
-    public RestaurantResponse.Create createRestaurant(RestaurantRequest.Create request) {
+    public RestaurantResponse.Create createRestaurant(RestaurantRequest.Create request, UUID regionId) {
         // 점주 인증 토큰 생성
         String ownerAuthToken = TokenGenerator.generateToken();
 
@@ -51,6 +51,7 @@ public class RestaurantService {
                 .ownerAuthToken(ownerAuthToken)
                 .ownerName(request.getOwnerName())
                 .businessRegNum(request.getBusinessRegNum())
+                .regionId(regionId)
                 .build();
 
         // 음식점 repository 저장

--- a/src/main/java/com/order/orderlink/restaurant/application/RestaurantService.java
+++ b/src/main/java/com/order/orderlink/restaurant/application/RestaurantService.java
@@ -1,5 +1,8 @@
 package com.order.orderlink.restaurant.application;
 
+import com.order.orderlink.category.domain.RestaurantCategory;
+import com.order.orderlink.category.domain.repository.JpaCategoryRepository;
+import com.order.orderlink.category.domain.repository.JpaRestaurantCategoryRepository;
 import com.order.orderlink.common.auth.UserDetailsImpl;
 import com.order.orderlink.common.enums.ErrorCode;
 import com.order.orderlink.common.exception.AuthException;
@@ -29,7 +32,9 @@ import java.util.stream.Collectors;
 public class RestaurantService {
 
     private final RestaurantRepository restaurantRepository;
+    private final JpaRestaurantCategoryRepository restaurantCategoryRepository;
     private final DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HH:mm");
+
     // 음식점 등록 API
     public RestaurantResponse.Create createRestaurant(RestaurantRequest.Create request) {
         // 점주 인증 토큰 생성
@@ -160,6 +165,42 @@ public class RestaurantService {
 
         return RestaurantResponse.GetRestaurants.builder()
                 .restaurants(restaurants)
+                .build();
+    }
+
+    // 카테고리별 음식점 조회 API
+    public RestaurantResponse.RestaurantsByCategory getRestaurantsByCategory(UUID categoryId) {
+        // 해당 카테고리 ID로 가져온 중간 테이블 리스트
+        List<RestaurantCategory> restaurantCategories = restaurantCategoryRepository.findAllByCategoryId(categoryId);
+
+        // 중간 테이블 리스트 -> 음식점 ID 리스트 변환
+        List<UUID> restaurantIds = restaurantCategories.stream()
+                .map(RestaurantCategory::getRestaurantId).toList();
+
+        // 음식점 ID 리스트로 음식점 리스트 조회
+        List<Restaurant> restaurants = restaurantRepository.findAllById(restaurantIds);
+
+        // 음식점 Entity List -> ResponseDto List
+        List<RestaurantResponse.RestaurantDto> restaurantDtos = restaurants.stream()
+                .map(restaurant -> RestaurantResponse.RestaurantDto.builder()
+                        .restaurantId(restaurant.getId())
+                        .name(restaurant.getName())
+                        .address(restaurant.getAddress())
+                        .phone(restaurant.getPhone())
+                        .description(restaurant.getDescription())
+                        .openTime(restaurant.getOpenTime().format(formatter))
+                        .closeTime(restaurant.getCloseTime().format(formatter))
+                        .businessStatus(restaurant.isBusinessStatus())
+                        .ownerName(restaurant.getOwnerName())
+                        .businessRegNum(restaurant.getBusinessRegNum())
+                        .avgRating(restaurant.getAvgRating())
+                        .ratingSum(restaurant.getRatingSum())
+                        .ratingCount(restaurant.getRatingCount())
+                        .build())
+                .toList();
+
+        return RestaurantResponse.RestaurantsByCategory.builder()
+                .restaurantsByCategory(restaurantDtos)
                 .build();
     }
 

--- a/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantRequest.java
+++ b/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantRequest.java
@@ -4,6 +4,8 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
+import java.util.UUID;
+
 public class RestaurantRequest {
 
     @Getter

--- a/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantResponse.java
+++ b/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantResponse.java
@@ -13,7 +13,7 @@ import java.util.UUID;
 @Builder
 @AllArgsConstructor
 public class RestaurantResponse {
-
+    // 음식점 등록 Response
     @Getter
     @Builder
     @AllArgsConstructor
@@ -22,6 +22,7 @@ public class RestaurantResponse {
         private final String ownerAuthToken;
     }
 
+    // 전체 음식점 조회 Response
     @Getter
     @Builder
     @AllArgsConstructor
@@ -29,6 +30,35 @@ public class RestaurantResponse {
         private final List<RestaurantDto> restaurants;
     }
 
+    // 해당 카테고리로 조회한 음식점 리스트 Response
+    @Builder
+    @AllArgsConstructor
+    public static class RestaurantsByCategory {
+        private final List<RestaurantDto> restaurantsByCategory;
+    }
+
+    // 음식점 DTO(foods 미포함) : 전체 음식점 조회 시 리스트에 담을 DTO
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
+    public static class RestaurantDto {
+        private UUID restaurantId;
+        private String name;
+        private String address;
+        private String phone;
+        private String description;
+        private String openTime;
+        private String closeTime;
+        private boolean businessStatus;
+        private String ownerName;
+        private String businessRegNum;
+        private Double avgRating;
+        private Double ratingSum;
+        private Integer ratingCount;
+    }
+
+    // 음식점 상세 Response(foods 포함)
     @Getter
     @Builder
     @AllArgsConstructor
@@ -50,26 +80,7 @@ public class RestaurantResponse {
         private List<GetRestaurantFoodDto> foods;
     }
 
-    @Getter
-    @Builder
-    @AllArgsConstructor
-    @NoArgsConstructor
-    public static class RestaurantDto {
-        private UUID restaurantId;
-        private String name;
-        private String address;
-        private String phone;
-        private String description;
-        private String openTime;
-        private String closeTime;
-        private boolean businessStatus;
-        private String ownerName;
-        private String businessRegNum;
-        private Double avgRating;
-        private Double ratingSum;
-        private Integer ratingCount;
-    }
-
+    // 음식 DTO : 음식점 상세 조회 시 음식 리스트에 담을 DTO
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
@@ -82,6 +93,7 @@ public class RestaurantResponse {
         private String imageUrl;
     }
 
+    // 음식점 수정 Response : 수정이 가능한 필드만 반환
     @Getter
     @AllArgsConstructor
     @NoArgsConstructor
@@ -99,6 +111,7 @@ public class RestaurantResponse {
         private String businessRegNum;
     }
 
+    // 음식점 삭제 Response
     @Getter
     @AllArgsConstructor
     public static class Delete {

--- a/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantResponse.java
+++ b/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantResponse.java
@@ -31,10 +31,12 @@ public class RestaurantResponse {
     }
 
     // 해당 카테고리로 조회한 음식점 리스트 Response
-    @Builder
+    @Getter
     @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
     public static class RestaurantsByCategory {
-        private final List<RestaurantDto> restaurantsByCategory;
+        List<RestaurantDto> restaurantsByCategory;
     }
 
     // 음식점 DTO(foods 미포함) : 전체 음식점 조회 시 리스트에 담을 DTO

--- a/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
@@ -1,21 +1,23 @@
 package com.order.orderlink.restaurant.domain;
 
-import java.time.LocalDateTime;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.order.orderlink.category.domain.RestaurantCategory;
+import com.order.orderlink.common.auth.util.LocalTimeToStringConverter;
+import com.order.orderlink.common.entity.BaseTimeEntity;
+import com.order.orderlink.food.domain.Food;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.UuidGenerator;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
-
-import jakarta.persistence.*;
-import lombok.*;
-import org.hibernate.annotations.UuidGenerator;
-import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.order.orderlink.common.auth.util.LocalTimeToStringConverter;
-import com.order.orderlink.common.entity.BaseTimeEntity;
-import com.order.orderlink.food.domain.Food;
 
 @Getter
 @NoArgsConstructor
@@ -78,6 +80,9 @@ public class Restaurant extends BaseTimeEntity {
 	@OneToMany(mappedBy = "restaurant", cascade = CascadeType.ALL, orphanRemoval = true)
 	@JsonIgnore
 	private List<Food> foods = new ArrayList<>();
+
+	@OneToMany
+	private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
 
 	private UUID regionId;
 

--- a/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
@@ -84,6 +84,7 @@ public class Restaurant extends BaseTimeEntity {
 	@OneToMany(mappedBy = "restaurant")
 	private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
 
+	@Column(name = "region_id", nullable = false)
 	private UUID regionId;
 
 	public void updateRatingSum(Double newRatingSum) {

--- a/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/Restaurant.java
@@ -81,7 +81,7 @@ public class Restaurant extends BaseTimeEntity {
 	@JsonIgnore
 	private List<Food> foods = new ArrayList<>();
 
-	@OneToMany
+	@OneToMany(mappedBy = "restaurant")
 	private List<RestaurantCategory> restaurantCategories = new ArrayList<>();
 
 	private UUID regionId;

--- a/src/main/java/com/order/orderlink/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/repository/RestaurantRepository.java
@@ -1,5 +1,6 @@
 package com.order.orderlink.restaurant.domain.repository;
 
+import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/order/orderlink/restaurant/presentation/RestaurantController.java
+++ b/src/main/java/com/order/orderlink/restaurant/presentation/RestaurantController.java
@@ -66,6 +66,16 @@ public class RestaurantController {
                 restaurantService.getRestaurant(restaurantId));
     }
 
+    // 카테고리별 음식점 조회 API
+    @GetMapping("/{categoryId}")
+    public SuccessResponse<RestaurantResponse.RestaurantsByCategory> getRestaurantByCategory(
+            @PathVariable("categoryId") UUID categoryId) {
+
+        return SuccessResponse.success(SuccessCode.RESTAURANTS_CATEGORY_GET_SUCCESS,
+                restaurantService.getRestaurantsByCategory(categoryId));
+    }
+
+
     // 음식점 수정 API
     @PutMapping("/{id}")
     @PreAuthorize("hasAnyAuthority('ROLE_OWNER', 'ROLE_MASTER')")

--- a/src/main/java/com/order/orderlink/restaurant/presentation/RestaurantController.java
+++ b/src/main/java/com/order/orderlink/restaurant/presentation/RestaurantController.java
@@ -43,10 +43,11 @@ public class RestaurantController {
     @PostMapping
     @PreAuthorize("hasAuthority('ROLE_MASTER')")
     public SuccessResponse<RestaurantResponse.Create> createRestaurant(
-        @Valid @RequestBody RestaurantRequest.Create request) {
+        @Valid @RequestBody RestaurantRequest.Create request,
+        @RequestParam UUID regionId) {
 
         return SuccessResponse.success(SuccessCode.RESTAURANT_CREATE_SUCCESS,
-                restaurantService.createRestaurant(request));
+                restaurantService.createRestaurant(request, regionId));
     }
 
     // 전체 음식점 목록 조회 API

--- a/src/main/java/com/order/orderlink/restaurant/presentation/RestaurantController.java
+++ b/src/main/java/com/order/orderlink/restaurant/presentation/RestaurantController.java
@@ -67,7 +67,7 @@ public class RestaurantController {
     }
 
     // 카테고리별 음식점 조회 API
-    @GetMapping("/{categoryId}")
+    @GetMapping("/{categoryId}/category")
     public SuccessResponse<RestaurantResponse.RestaurantsByCategory> getRestaurantByCategory(
             @PathVariable("categoryId") UUID categoryId) {
 


### PR DESCRIPTION
- pathVariable로 검색할 카테고리의 UUID 입력
- 해당 카테고리의 UUID를 통해 음식점&카테고리의 중간 테이블 리스트를 조회
- 중간 테이블 리스트를 음식점 엔티티 리스트로 변환
- 음식점 엔티티를 응답 DTO에 담아 반환

음식점 등록 시 regionId 추가
- regionId를 QueryString으로 받아 음식점 등록 시 해당 음식점의 region 컬럼에 저장