### PR TITLE
[Refactor] Address, Ai, Review, User, Common 리팩터링

### DIFF
--- a/src/main/java/com/order/orderlink/address/application/AddressService.java
+++ b/src/main/java/com/order/orderlink/address/application/AddressService.java
@@ -102,7 +102,7 @@ public class AddressService {
 	// 배송지 삭제 (soft delete)
 	public void deleteAddress(UUID addressId, UUID currentUserId, String username) {
 		Address address = getAddressInstance(addressId, currentUserId);
-		address.softDelete(username);
+		address.deleteSoftly(username);
 	}
 
 	//

--- a/src/main/java/com/order/orderlink/address/application/AddressService.java
+++ b/src/main/java/com/order/orderlink/address/application/AddressService.java
@@ -12,8 +12,8 @@ import com.order.orderlink.address.application.dtos.AddressRequest;
 import com.order.orderlink.address.application.dtos.AddressResponse;
 import com.order.orderlink.address.domain.Address;
 import com.order.orderlink.address.domain.repository.AddressRepository;
-import com.order.orderlink.common.enums.ErrorCode;
 import com.order.orderlink.address.exception.AddressException;
+import com.order.orderlink.common.enums.ErrorCode;
 import com.order.orderlink.user.domain.User;
 
 import lombok.RequiredArgsConstructor;
@@ -41,7 +41,7 @@ public class AddressService {
 			.isDefault(Boolean.TRUE.equals(request.getIsDefault()))
 			.build();
 		addressRepository.save(address);
-		return new AddressResponse.Create(address.getId());
+		return AddressResponse.Create.builder().id(address.getId()).build();
 	}
 
 	// 배송지 목록 조회
@@ -49,30 +49,35 @@ public class AddressService {
 	public AddressResponse.ReadAll getAddresses(UUID userId, Pageable pageable) {
 		Page<Address> page = addressRepository.findByUserIdAndDeletedAtIsNull(userId, pageable);
 		List<AddressResponse.Read> addresses = page.getContent().stream()
-			.map(address -> new AddressResponse.Read(
-				address.getId(),
-				address.getAddress(),
-				address.getIsDefault(),
-				address.getCreatedAt()
-			))
+			.map(address -> AddressResponse.Read.builder()
+				.id(address.getId())
+				.address(address.getAddress())
+				.isDefault(address.getIsDefault())
+				.createdAt(address.getCreatedAt())
+				.build())
 			.toList();
-		return new AddressResponse.ReadAll(addresses, page.getNumber() + 1, page.getTotalPages(),
-			page.getTotalElements());
+		return AddressResponse.ReadAll.builder()
+			.addresses(addresses)
+			.currentPage(page.getNumber() + 1)
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.build();
 	}
 
 	// 배송지 상세 조회
 	@Transactional(readOnly = true)
 	public AddressResponse.Read getAddressInfo(UUID addressId, UUID currentUserId) {
 		Address address = getAddressInstance(addressId, currentUserId);
-		return new AddressResponse.Read(
-			address.getId(),
-			address.getAddress(),
-			address.getIsDefault(),
-			address.getCreatedAt()
-		);
+		return AddressResponse.Read.builder()
+			.id(address.getId())
+			.address(address.getAddress())
+			.isDefault(address.getIsDefault())
+			.createdAt(address.getCreatedAt())
+			.build();
 	}
 
 	// 배송지 수정
+	@Transactional
 	public AddressResponse.Update updateAddress(UUID addressId, UUID currentUserId, AddressRequest.Update request) {
 		Address address = getAddressInstance(addressId, currentUserId);
 
@@ -87,7 +92,11 @@ public class AddressService {
 		}
 
 		address.update(request.getAddress(), request.getIsDefault());
-		return new AddressResponse.Update(address.getId(), address.getAddress(), address.getIsDefault());
+		return AddressResponse.Update.builder()
+			.id(address.getId())
+			.address(address.getAddress())
+			.isDefault(address.getIsDefault())
+			.build();
 	}
 
 	// 배송지 삭제 (soft delete)

--- a/src/main/java/com/order/orderlink/address/application/dtos/AddressRequest.java
+++ b/src/main/java/com/order/orderlink/address/application/dtos/AddressRequest.java
@@ -1,11 +1,16 @@
 package com.order.orderlink.address.application.dtos;
 
 import jakarta.validation.constraints.NotBlank;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class AddressRequest {
 
 	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
 		@NotBlank(message = "배송 주소는 필수 입력 항목입니다.")
 		private String address;
@@ -13,6 +18,8 @@ public class AddressRequest {
 	}
 
 	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
 		private String address;
 		private Boolean isDefault;

--- a/src/main/java/com/order/orderlink/address/application/dtos/AddressResponse.java
+++ b/src/main/java/com/order/orderlink/address/application/dtos/AddressResponse.java
@@ -4,7 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -12,13 +14,15 @@ import lombok.Getter;
 public class AddressResponse {
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
 		private UUID id;
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class ReadAll {
 		private List<AddressResponse.Read> addresses;
 		private int currentPage;
@@ -27,7 +31,8 @@ public class AddressResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Read {
 		private UUID id;
 		private String address;
@@ -36,7 +41,8 @@ public class AddressResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
 		private UUID id;
 		private String address;

--- a/src/main/java/com/order/orderlink/address/domain/Address.java
+++ b/src/main/java/com/order/orderlink/address/domain/Address.java
@@ -63,4 +63,8 @@ public class Address extends BaseTimeEntity {
 		}
 	}
 
+	public void deleteSoftly(String deletedBy) {
+		super.softDelete(deletedBy);
+	}
+
 }

--- a/src/main/java/com/order/orderlink/ai/application/AiApiService.java
+++ b/src/main/java/com/order/orderlink/ai/application/AiApiService.java
@@ -16,8 +16,8 @@ import com.order.orderlink.ai.application.dtos.AiApiRequest;
 import com.order.orderlink.ai.application.dtos.AiApiResponse;
 import com.order.orderlink.ai.domain.AiApiLog;
 import com.order.orderlink.ai.domain.repository.AiApiLogRepository;
-import com.order.orderlink.common.enums.ErrorCode;
 import com.order.orderlink.ai.exception.AiApiException;
+import com.order.orderlink.common.enums.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,31 +33,52 @@ public class AiApiService {
 	@Value("${ai.api.key}")
 	private String apiKey;
 
+	private static final int MAX_INPUT_LENGTH = 100; // AI API 요청 텍스트 최대 길이
+	private static final String ADDITIONAL_INSTRUCTION = " 답변을 최대한 간결하게 50자 이하로";
+
 	public AiApiResponse.GenerateDescription generateDescription(UUID userId,
 		AiApiRequest.GenerateDescription requestDto) {
 
-		int MAX_INPUT_LENGTH = 100; // AI API 요청 텍스트 최대 길이
+		String inputText = truncateText(requestDto.getBaseText());
+		String formattedRequestText = inputText + ADDITIONAL_INSTRUCTION;
 
-		String baseText = requestDto.getBaseText();
+		Map<String, Object> payload = createPayload(formattedRequestText);
 
-		if (baseText.length() > MAX_INPUT_LENGTH) {
-			baseText = baseText.substring(0, MAX_INPUT_LENGTH);
-			log.info("요청 텍스트가 {}자를 초과하여 {}자로 자름", MAX_INPUT_LENGTH, baseText.length());
+		log.info("상품 설명 생성 요청 userId: {}, input: {}", userId, inputText);
+
+		String responseBody = sendRequest(payload);
+		String recommendedDescription = parseDescriptionFromResponse(responseBody);
+
+		log.info("상품 설명 생성 응답: {}", recommendedDescription);
+
+		saveApiLog(userId, inputText, recommendedDescription);
+
+		return AiApiResponse.GenerateDescription.builder()
+			.description(recommendedDescription)
+			.build();
+	}
+
+	private String truncateText(String text) {
+		if (text.length() > MAX_INPUT_LENGTH) {
+			String truncatedText = text.substring(0, MAX_INPUT_LENGTH);
+			log.info("요청 텍스트가 {}자를 초과하여 {}자로 자름", MAX_INPUT_LENGTH, truncatedText.length());
+			return truncatedText;
 		}
+		return text;
+	}
 
-		// 요청 텍스트에 추가 지시문 첨부
-		String finalRequestText = baseText + " 답변을 최대한 간결하게 50자 이하로";
-
-		// AI API에 보낼 payload 구성 (요청 JSON 구조)
+	private Map<String, Object> createPayload(String requestText) {
 		Map<String, Object> payload = new HashMap<>();
 		Map<String, Object> contentMap = new HashMap<>();
 		Map<String, String> part = new HashMap<>();
-		part.put("text", finalRequestText);
-		contentMap.put("parts", new Map[] {part}); // parts 는 배열 형태로 전달
+		part.put("text", requestText);
+		contentMap.put("parts", new Map[] {part});
 		payload.put("contents", new Map[] {contentMap});
+		return payload;
+	}
 
-		log.info("상품 설명 생성 요청 userId: {}, input: {}", userId, baseText);
-		String responseBody = aiWebClient.post()
+	private String sendRequest(Map<String, Object> payload) {
+		return aiWebClient.post()
 			.uri(uriBuilder -> uriBuilder
 				.path("/v1beta/models/gemini-1.5-flash-latest:generateContent")
 				.queryParam("key", apiKey)
@@ -67,24 +88,9 @@ public class AiApiService {
 			.retrieve()
 			.bodyToMono(String.class)
 			.block();
-
-		String recommendedDescription = extractDescription(responseBody);
-		log.info("상품 설명 생성 응답: {}", recommendedDescription);
-
-		// DB에 API 로그 저장
-		AiApiLog aiApiLog = AiApiLog.builder()
-			.userId(userId)
-			.requestText(baseText)
-			.responseText(recommendedDescription)
-			.build();
-		aiApiLogRepository.save(aiApiLog);
-
-		return new AiApiResponse.GenerateDescription(recommendedDescription);
 	}
 
-	private String extractDescription(String responseBody) {
-		// 응답 JSON 구조에서 추천 설명 추출
-		// 예시: {"contents":[{"parts":[{"text":"상품 설명"}]}]}
+	private String parseDescriptionFromResponse(String responseBody) {
 		try {
 			ObjectMapper objectMapper = new ObjectMapper();
 			JsonNode root = objectMapper.readTree(responseBody);
@@ -102,6 +108,15 @@ public class AiApiService {
 			throw new AiApiException(ErrorCode.AI_API_RESPONSE_PARSING_ERROR);
 		}
 		return "";
+	}
+
+	private void saveApiLog(UUID userId, String requestText, String responseText) {
+		AiApiLog aiApiLog = AiApiLog.builder()
+			.userId(userId)
+			.requestText(requestText)
+			.responseText(responseText)
+			.build();
+		aiApiLogRepository.save(aiApiLog);
 	}
 
 }

--- a/src/main/java/com/order/orderlink/ai/application/dtos/AiApiRequest.java
+++ b/src/main/java/com/order/orderlink/ai/application/dtos/AiApiRequest.java
@@ -2,11 +2,16 @@ package com.order.orderlink.ai.application.dtos;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 public class AiApiRequest {
 
 	@Getter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class GenerateDescription {
 		@NotBlank(message = "입력 텍스트는 필수입니다.")
 		@Size(max = 100, message = "입력 텍스트는 최대 100자까지 입력 가능합니다.")

--- a/src/main/java/com/order/orderlink/ai/application/dtos/AiApiResponse.java
+++ b/src/main/java/com/order/orderlink/ai/application/dtos/AiApiResponse.java
@@ -1,12 +1,15 @@
 package com.order.orderlink.ai.application.dtos;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 public class AiApiResponse {
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class GenerateDescription {
 		private String description;
 	}

--- a/src/main/java/com/order/orderlink/ai/presentation/AiApiController.java
+++ b/src/main/java/com/order/orderlink/ai/presentation/AiApiController.java
@@ -12,10 +12,10 @@ import org.springframework.web.bind.annotation.RestController;
 import com.order.orderlink.ai.application.AiApiService;
 import com.order.orderlink.ai.application.dtos.AiApiRequest;
 import com.order.orderlink.ai.application.dtos.AiApiResponse;
+import com.order.orderlink.ai.exception.AiApiException;
 import com.order.orderlink.common.auth.UserDetailsImpl;
 import com.order.orderlink.common.dtos.SuccessResponse;
 import com.order.orderlink.common.enums.SuccessCode;
-import com.order.orderlink.ai.exception.AiApiException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/order/orderlink/common/auth/service/ServiceAccountTokenService.java
+++ b/src/main/java/com/order/orderlink/common/auth/service/ServiceAccountTokenService.java
@@ -67,16 +67,9 @@ public class ServiceAccountTokenService {
 	@Getter
 	@Setter
 	public static class TokenResponse {
-		private String access_token;
-		private int expires_in;
+		private String accessToken;
+		private int expiresIn;
 
-		public String getAccessToken() {
-			return access_token;
-		}
-
-		public int getExpiresIn() {
-			return expires_in;
-		}
 	}
 
 }

--- a/src/main/java/com/order/orderlink/common/auth/util/LocalTimeToStringConverter.java
+++ b/src/main/java/com/order/orderlink/common/auth/util/LocalTimeToStringConverter.java
@@ -1,20 +1,20 @@
 package com.order.orderlink.common.auth.util;
 
-import jakarta.persistence.AttributeConverter;
-
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
+import jakarta.persistence.AttributeConverter;
+
 public class LocalTimeToStringConverter implements AttributeConverter<LocalTime, String> {
-    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
+	private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ofPattern("HH:mm");
 
-    @Override
-    public String convertToDatabaseColumn(LocalTime localTime) {
-        return (localTime == null) ? null : localTime.format(FORMATTER);
-    }
+	@Override
+	public String convertToDatabaseColumn(LocalTime localTime) {
+		return (localTime == null) ? null : localTime.format(FORMATTER);
+	}
 
-    @Override
-    public LocalTime convertToEntityAttribute(String dbData) {
-        return (dbData == null || dbData.isEmpty()) ? null : LocalTime.parse(dbData, FORMATTER);
-    }
+	@Override
+	public LocalTime convertToEntityAttribute(String dbData) {
+		return (dbData == null || dbData.isEmpty()) ? null : LocalTime.parse(dbData, FORMATTER);
+	}
 }

--- a/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantRequest.java
+++ b/src/main/java/com/order/orderlink/restaurant/application/dtos/RestaurantRequest.java
@@ -4,64 +4,62 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
-import java.util.UUID;
-
 public class RestaurantRequest {
 
-    @Getter
-    public static class Create {
-        @NotBlank
-        private String name;
+	@Getter
+	public static class Create {
+		@NotBlank
+		private String name;
 
-        @NotBlank
-        private String address;
+		@NotBlank
+		private String address;
 
-        @Pattern(regexp = "^[0-9]{10,11}$", message = "-를 제외한 10자리 또는 11자리 숫자로 입력해주세요.")
-        @NotBlank
-        private String phone;
+		@Pattern(regexp = "^[0-9]{10,11}$", message = "-를 제외한 10자리 또는 11자리 숫자로 입력해주세요.")
+		@NotBlank
+		private String phone;
 
-        private String description;
+		private String description;
 
-        @NotBlank
-        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 시작 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
-        private String openTime;
+		@NotBlank
+		@Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 시작 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
+		private String openTime;
 
-        @NotBlank
-        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 종료 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
-        private String closeTime;
+		@NotBlank
+		@Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 종료 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
+		private String closeTime;
 
-        @NotBlank
-        private String ownerName;
+		@NotBlank
+		private String ownerName;
 
-        @NotBlank
-        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 '-'를 포함하여 000-00-00000 형식으로 입력해야 합니다.")
-        private String businessRegNum;
-    }
+		@NotBlank
+		@Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 '-'를 포함하여 000-00-00000 형식으로 입력해야 합니다.")
+		private String businessRegNum;
+	}
 
-    @Getter
-    public static class Update {
-        private String name;
+	@Getter
+	public static class Update {
+		private String name;
 
-        private String address;
+		private String address;
 
-        @Pattern(regexp = "^[0-9]{10,11}$", message = "-를 제외한 10자리 또는 11자리 숫자로 입력해주세요.")
-        private String phone;
+		@Pattern(regexp = "^[0-9]{10,11}$", message = "-를 제외한 10자리 또는 11자리 숫자로 입력해주세요.")
+		private String phone;
 
-        private String description;
+		private String description;
 
-        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$",message = "영업 시작 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
-        private String openTime;
+		@Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 시작 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
+		private String openTime;
 
-        @Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 종료 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
-        private String closeTime;
+		@Pattern(regexp = "^([01]\\d|2[0-3]):[0-5]\\d$", message = "영업 종료 시간은 00:00 ~ 23:59 이내의 시간으로 HH:mm 형식에 맞게 입력해 주세요.")
+		private String closeTime;
 
-        private String ownerName;
+		private String ownerName;
 
-        @Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 '-'를 포함하여 000-00-00000 형식으로 입력해야 합니다.")
-        private String businessRegNum;
+		@Pattern(regexp = "^\\d{3}-\\d{2}-\\d{5}$", message = "사업자 등록 번호는 '-'를 포함하여 000-00-00000 형식으로 입력해야 합니다.")
+		private String businessRegNum;
 
-        @NotBlank(message = "점주 인증 토큰은 필수 입력입니다.")
-        @Pattern(regexp = "^[A-Za-z0-9_-]{22}$", message = "점주 인증 토큰이 올바르지 않습니다.")
-        private String ownerAuthToken;
-    }
+		@NotBlank(message = "점주 인증 토큰은 필수 입력입니다.")
+		@Pattern(regexp = "^[A-Za-z0-9_-]{22}$", message = "점주 인증 토큰이 올바르지 않습니다.")
+		private String ownerAuthToken;
+	}
 }

--- a/src/main/java/com/order/orderlink/restaurant/domain/repository/RestaurantRepository.java
+++ b/src/main/java/com/order/orderlink/restaurant/domain/repository/RestaurantRepository.java
@@ -1,6 +1,5 @@
 package com.order.orderlink.restaurant.domain.repository;
 
-import java.util.List;
 import java.util.UUID;
 
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/src/main/java/com/order/orderlink/review/application/ReviewService.java
+++ b/src/main/java/com/order/orderlink/review/application/ReviewService.java
@@ -89,7 +89,9 @@ public class ReviewService {
 		restaurant.updateRatingCount(newRatingCount);
 		restaurant.updateAvgRating(newRatingSum / newRatingCount);
 		restaurantRepository.save(restaurant);
-		return new ReviewResponse.Create(review.getId());
+		return ReviewResponse.Create.builder()
+			.reviewId(review.getId())
+			.build();
 	}
 
 	// 특정 음식점에 대한 페이징 처리된 리뷰 목록 조회
@@ -108,8 +110,12 @@ public class ReviewService {
 				.createdAt(review.getCreatedAt())
 				.build();
 		}).toList();
-		return new ReviewResponse.ReviewPageResponse(reviews, page.getNumber() + 1, page.getTotalPages(),
-			page.getTotalElements());
+		return ReviewResponse.ReviewPageResponse.builder()
+			.reviews(reviews)
+			.currentPage(page.getNumber() + 1)
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.build();
 	}
 
 	// 리뷰 상세 조회: 특정 리뷰의 전체 정보를 반환, 주문 상세 정보(주문 ID, 주문 날짜, 주문 상품) 포함
@@ -185,7 +191,7 @@ public class ReviewService {
 		}
 
 		Restaurant restaurant = review.getRestaurant();
-		review.softDelete(currentUsername);
+		review.deleteSoftly(currentUsername);
 
 		// 음식점 평점 집계 업데이트
 		Double newRatingSum = restaurant.getRatingSum() - review.getRating();

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewRequest.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewRequest.java
@@ -4,13 +4,18 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class ReviewRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
 
 		@NotNull(message = "평점은 필수입니다.")
@@ -24,6 +29,8 @@ public class ReviewRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
 
 		@Min(value = 1, message = "평점은 최소 1점이어야 합니다.")

--- a/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
+++ b/src/main/java/com/order/orderlink/review/application/dtos/ReviewResponse.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,14 +13,14 @@ public class ReviewResponse {
 
 	@Getter
 	@Builder
-	@AllArgsConstructor
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
 		private UUID reviewId;
 	}
 
 	@Getter
 	@Builder
-	@AllArgsConstructor
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
 		private UUID reviewId;
 		private UUID restaurantId;
@@ -32,7 +33,7 @@ public class ReviewResponse {
 
 	@Getter
 	@Builder
-	@AllArgsConstructor
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class ReviewPageResponse {
 		private List<ReviewResponse.Summary> reviews;
 		private Integer currentPage; // 1-based
@@ -43,7 +44,7 @@ public class ReviewResponse {
 	// 리뷰 목록 조회 응답 DTO (간략한 정보)
 	@Getter
 	@Builder
-	@AllArgsConstructor
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Summary {
 		private UUID reviewId;
 		private String userNickname; // 리뷰 작성자의 닉네임
@@ -55,7 +56,7 @@ public class ReviewResponse {
 	// 리뷰 상세 조회 응답 DTO (자세한 정보)
 	@Getter
 	@Builder
-	@AllArgsConstructor
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Detail {
 		private UUID reviewId;
 		private String userNickname;
@@ -68,7 +69,7 @@ public class ReviewResponse {
 
 	@Getter
 	@Builder
-	@AllArgsConstructor
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class OrderDetails {
 		private UUID orderId;
 		private LocalDateTime orderDate;

--- a/src/main/java/com/order/orderlink/review/domain/Review.java
+++ b/src/main/java/com/order/orderlink/review/domain/Review.java
@@ -71,7 +71,7 @@ public class Review extends BaseTimeEntity {
 		}
 	}
 
-	public void softDelete(String deletedBy) {
+	public void deleteSoftly(String deletedBy) {
 		super.softDelete(deletedBy);
 	}
 

--- a/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
+++ b/src/main/java/com/order/orderlink/review/presentation/ReviewController.java
@@ -23,10 +23,10 @@ import com.order.orderlink.common.dtos.SuccessResponse;
 import com.order.orderlink.common.enums.SuccessCode;
 import com.order.orderlink.order.exception.OrderException;
 import com.order.orderlink.restaurant.exception.RestaurantException;
-import com.order.orderlink.review.exception.ReviewException;
 import com.order.orderlink.review.application.ReviewService;
 import com.order.orderlink.review.application.dtos.ReviewRequest;
 import com.order.orderlink.review.application.dtos.ReviewResponse;
+import com.order.orderlink.review.exception.ReviewException;
 
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/order/orderlink/user/application/UserService.java
+++ b/src/main/java/com/order/orderlink/user/application/UserService.java
@@ -10,12 +10,12 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.order.orderlink.common.enums.ErrorCode;
-import com.order.orderlink.user.exception.UserException;
 import com.order.orderlink.user.application.dtos.UserRequest;
 import com.order.orderlink.user.application.dtos.UserResponse;
 import com.order.orderlink.user.domain.User;
 import com.order.orderlink.user.domain.UserRoleEnum;
 import com.order.orderlink.user.domain.repository.UserRepository;
+import com.order.orderlink.user.exception.UserException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -42,48 +42,85 @@ public class UserService {
 
 		userRepository.save(user);
 
-		return new UserResponse.Create(user.getId());
+		return UserResponse.Create.builder().id(user.getId()).build();
 	}
 
 	// 전체 회원 조회
+	@Transactional(readOnly = true)
 	public UserResponse.ReadUserList getAllUsers(Pageable pageable) {
 		Page<User> page = userRepository.findAll(pageable);
 		List<UserResponse.Read> users = page.getContent()
 			.stream()
-			.map(user -> new UserResponse.Read(user.getId(), user.getUsername(), user.getEmail(), user.getPhone(),
-				user.getNickname(), user.getRole().name(), user.getIsPublic(), user.getCreatedAt()))
+			.map(user -> UserResponse.Read.builder()
+				.id(user.getId())
+				.username(user.getUsername())
+				.email(user.getEmail())
+				.phone(user.getPhone())
+				.nickname(user.getNickname())
+				.role(user.getRole().name())
+				.isPublic(user.getIsPublic())
+				.createdAt(user.getCreatedAt())
+				.build())
 			.toList();
-		return new UserResponse.ReadUserList(users, page.getNumber() + 1, page.getTotalPages(),
-			page.getTotalElements());
+		return UserResponse.ReadUserList.builder()
+			.users(users)
+			.currentPage(page.getNumber() + 1)
+			.totalPages(page.getTotalPages())
+			.totalElements(page.getTotalElements())
+			.build();
 	}
 
 	// 내 정보 조회
 	@Transactional(readOnly = true)
 	public UserResponse.Read getMyInfo(UUID userId) {
 		User user = getUser(userId);
-		return new UserResponse.Read(user.getId(), user.getUsername(), user.getEmail(), user.getPhone(),
-			user.getNickname(), user.getRole().name(), user.getIsPublic(), user.getCreatedAt());
+		return UserResponse.Read.builder()
+			.id(user.getId())
+			.username(user.getUsername())
+			.email(user.getEmail())
+			.phone(user.getPhone())
+			.nickname(user.getNickname())
+			.role(user.getRole().name())
+			.isPublic(user.getIsPublic())
+			.createdAt(user.getCreatedAt())
+			.build();
 	}
 
 	// 관리자 권한으로 특정 회원 정보 조회
 	@Transactional(readOnly = true)
 	public UserResponse.Read getUserInfoByAdmin(UUID userId) {
 		User user = getUser(userId);
-		return new UserResponse.Read(user.getId(), user.getUsername(), user.getEmail(), user.getPhone(),
-			user.getNickname(), user.getRole().name(), user.getIsPublic(), user.getCreatedAt());
+		return UserResponse.Read.builder()
+			.id(user.getId())
+			.username(user.getUsername())
+			.email(user.getEmail())
+			.phone(user.getPhone())
+			.nickname(user.getNickname())
+			.role(user.getRole().name())
+			.isPublic(user.getIsPublic())
+			.createdAt(user.getCreatedAt())
+			.build();
 	}
 
 	// 회원 정보 수정
+	@Transactional
 	public UserResponse.Update updateInfo(UUID userId, UserRequest.Update request) {
 		User user = getUser(userId);
 
 		user.updateInfo(request.getEmail(), request.getPhone(), request.getNickname(), request.getIsPublic());
 
-		return new UserResponse.Update(user.getId(), user.getUsername(), user.getEmail(), user.getPhone(),
-			user.getNickname(), user.getIsPublic());
+		return UserResponse.Update.builder()
+			.id(user.getId())
+			.username(user.getUsername())
+			.email(user.getEmail())
+			.phone(user.getPhone())
+			.nickname(user.getNickname())
+			.isPublic(user.getIsPublic())
+			.build();
 	}
 
 	// 관리자 권한으로 특정 회원 정보 수정
+	@Transactional
 	public UserResponse.UpdateByAdmin updateInfoByAdmin(UUID userId, UserRequest.UpdateByAdmin request) {
 		User user = getUser(userId);
 
@@ -97,11 +134,19 @@ public class UserService {
 				UserRoleEnum.valueOf(request.getRole()));
 		}
 
-		return new UserResponse.UpdateByAdmin(user.getId(), user.getUsername(), user.getEmail(), user.getPhone(),
-			user.getNickname(), user.getIsPublic(), user.getRole().name());
+		return UserResponse.UpdateByAdmin.builder()
+			.id(user.getId())
+			.username(user.getUsername())
+			.email(user.getEmail())
+			.phone(user.getPhone())
+			.nickname(user.getNickname())
+			.isPublic(user.getIsPublic())
+			.role(user.getRole().name())
+			.build();
 	}
 
 	// 비밀번호 변경
+	@Transactional
 	public UserResponse.UpdatePassword updatePassword(UUID userId, UserRequest.UpdatePassword request) {
 		User user = getUser(userId);
 
@@ -118,10 +163,11 @@ public class UserService {
 		// 새 비밀번호 암호화 및 변경
 		user.updatePassword(passwordEncoder.encode(request.getNewPassword()));
 
-		return new UserResponse.UpdatePassword(user.getId());
+		return UserResponse.UpdatePassword.builder().id(user.getId()).build();
 	}
 
 	// 회원 삭제/탈퇴
+	@Transactional
 	public UserResponse.Delete softDeleteUser(UUID userId, String username, String password) {
 		User user = getUser(userId);
 
@@ -132,7 +178,10 @@ public class UserService {
 
 		user.softDelete(username);  // BaseTimeEntity에 구현한 softDelete 메서드 (deletedBy, deletedAt 필드 업데이트)
 
-		return new UserResponse.Delete(user.getId(), user.getDeletedAt());
+		return UserResponse.Delete.builder()
+			.id(user.getId())
+			.deletedAt(user.getDeletedAt())
+			.build();
 	}
 
 	@Transactional(readOnly = true)

--- a/src/main/java/com/order/orderlink/user/application/UserService.java
+++ b/src/main/java/com/order/orderlink/user/application/UserService.java
@@ -176,7 +176,7 @@ public class UserService {
 			throw new UserException(ErrorCode.USER_PASSWORD_NOT_MATCH);
 		}
 
-		user.softDelete(username);  // BaseTimeEntity에 구현한 softDelete 메서드 (deletedBy, deletedAt 필드 업데이트)
+		user.deleteSoftly(username);  // BaseTimeEntity에 구현한 softDelete 메서드 (deletedBy, deletedAt 필드 업데이트)
 
 		return UserResponse.Delete.builder()
 			.id(user.getId())

--- a/src/main/java/com/order/orderlink/user/application/dtos/UserRequest.java
+++ b/src/main/java/com/order/orderlink/user/application/dtos/UserRequest.java
@@ -4,13 +4,18 @@ import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 public class UserRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
 
 		@Size(min = 4, max = 10, message = "아이디는 4자 이상 10자 이하이어야 합니다.")
@@ -42,6 +47,8 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
 
 		@Email(message = "이메일 형식이 올바르지 않습니다.")
@@ -57,6 +64,8 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class UpdateByAdmin {
 
 		@Email(message = "이메일 형식이 올바르지 않습니다.")
@@ -75,6 +84,8 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class UpdatePassword {
 
 		@NotBlank(message = "현재 비밀번호를 입력해 주세요.")
@@ -92,6 +103,8 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@NoArgsConstructor(access = AccessLevel.PRIVATE)
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Delete {
 
 		@NotBlank(message = "확인을 위해 현재 비밀번호를 입력해 주세요.")

--- a/src/main/java/com/order/orderlink/user/application/dtos/UserRequest.java
+++ b/src/main/java/com/order/orderlink/user/application/dtos/UserRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
@@ -14,6 +15,7 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@Builder
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
@@ -47,6 +49,7 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@Builder
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
@@ -64,6 +67,7 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@Builder
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class UpdateByAdmin {
@@ -84,6 +88,7 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@Builder
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class UpdatePassword {
@@ -103,6 +108,7 @@ public class UserRequest {
 
 	@Getter
 	@Setter
+	@Builder
 	@NoArgsConstructor(access = AccessLevel.PRIVATE)
 	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Delete {

--- a/src/main/java/com/order/orderlink/user/application/dtos/UserResponse.java
+++ b/src/main/java/com/order/orderlink/user/application/dtos/UserResponse.java
@@ -4,7 +4,9 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.UUID;
 
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -12,13 +14,15 @@ import lombok.Getter;
 public class UserResponse {
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Create {
 		private UUID id;
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Read {
 		private UUID id;
 		private String username;
@@ -31,7 +35,8 @@ public class UserResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class ReadUserList {
 		private List<Read> users;
 		private int currentPage;
@@ -40,7 +45,8 @@ public class UserResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Update {
 		private UUID id;
 		private String username;
@@ -51,7 +57,8 @@ public class UserResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class UpdateByAdmin {
 		private UUID id;
 		private String username;
@@ -63,13 +70,15 @@ public class UserResponse {
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class UpdatePassword {
 		private UUID id;
 	}
 
 	@Getter
-	@AllArgsConstructor
+	@Builder
+	@AllArgsConstructor(access = AccessLevel.PRIVATE)
 	public static class Delete {
 		private UUID id;
 		private LocalDateTime deletedAt;

--- a/src/main/java/com/order/orderlink/user/domain/User.java
+++ b/src/main/java/com/order/orderlink/user/domain/User.java
@@ -107,7 +107,7 @@ public class User extends BaseTimeEntity {
 		this.password = newEncodedPassword;
 	}
 
-	public void softDelete(String deletedBy) {
+	public void deleteSoftly(String deletedBy) {
 		super.softDelete(deletedBy);
 		addresses.forEach(address -> address.softDelete(deletedBy));
 	}

--- a/src/test/java/com/order/orderlink/user/application/UserServiceTest.java
+++ b/src/test/java/com/order/orderlink/user/application/UserServiceTest.java
@@ -59,13 +59,14 @@ public class UserServiceTest {
 	@DisplayName("회원가입 성공")
 	public void testSignup_Success() {
 		// Given
-		UserRequest.Create request = new UserRequest.Create();
-		request.setUsername("testuser");
-		request.setNickname("Test Nick");
-		request.setEmail("test@example.com");
-		request.setPhone("01012345678");
-		request.setPassword("password");
-		request.setRole("CUSTOMER");
+		UserRequest.Create request = UserRequest.Create.builder()
+			.username("testuser")
+			.nickname("Test Nick")
+			.email("test@example.com")
+			.phone("01012345678")
+			.password("password")
+			.role("CUSTOMER")
+			.build();
 
 		when(userRepository.existsByUsername("testuser")).thenReturn(false);
 		when(userRepository.existsByEmail("test@example.com")).thenReturn(false);
@@ -90,13 +91,14 @@ public class UserServiceTest {
 	@DisplayName("회원가입 실패: 중복된 아이디")
 	public void testSignup_Duplicate() {
 		// Given
-		UserRequest.Create request = new UserRequest.Create();
-		request.setUsername("testuser");
-		request.setNickname("Test Nick");
-		request.setEmail("test@example.com");
-		request.setPhone("01012345678");
-		request.setPassword("password");
-		request.setRole("USER");
+		UserRequest.Create request = UserRequest.Create.builder()
+			.username("testuser")
+			.nickname("Test Nick")
+			.email("test@example.com")
+			.phone("01012345678")
+			.password("password")
+			.role("CUSTOMER")
+			.build();
 
 		when(userRepository.existsByUsername("testuser")).thenReturn(true);
 
@@ -149,11 +151,12 @@ public class UserServiceTest {
 	@Test
 	public void testUpdateInfo() {
 		// Given
-		UserRequest.Update request = new UserRequest.Update();
-		request.setEmail("new@example.com");
-		request.setPhone("01098765432");
-		request.setNickname("New Nick");
-		request.setIsPublic(false);
+		UserRequest.Update request = UserRequest.Update.builder()
+			.email("new@example.com")
+			.phone("01098765432")
+			.nickname("New Nick")
+			.isPublic(false)
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 
@@ -172,12 +175,13 @@ public class UserServiceTest {
 	@DisplayName("회원 정보 수정 (관리자): 성공")
 	public void testUpdateInfoByAdmin_WithRole() {
 		// Given
-		UserRequest.UpdateByAdmin request = new UserRequest.UpdateByAdmin();
-		request.setEmail("adminupdate@example.com");
-		request.setPhone("01011112222");
-		request.setNickname("Admin Nick");
-		request.setIsPublic(true);
-		request.setRole("OWNER");
+		UserRequest.UpdateByAdmin request = UserRequest.UpdateByAdmin.builder()
+			.email("adminupdate@example.com")
+			.phone("01011112222")
+			.nickname("Admin Nick")
+			.isPublic(true)
+			.role("OWNER")
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 
@@ -197,10 +201,11 @@ public class UserServiceTest {
 	@DisplayName("비밀번호 변경 성공")
 	public void testUpdatePassword_Success() {
 		// Given
-		UserRequest.UpdatePassword request = new UserRequest.UpdatePassword();
-		request.setCurrentPassword("currentPass");
-		request.setNewPassword("newPass");
-		request.setNewPasswordConfirm("newPass");
+		UserRequest.UpdatePassword request = UserRequest.UpdatePassword.builder()
+			.currentPassword("currentPass")
+			.newPassword("newPass")
+			.newPasswordConfirm("newPass")
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 		when(passwordEncoder.matches("currentPass", dummyUser.getPassword())).thenReturn(true);
@@ -218,10 +223,11 @@ public class UserServiceTest {
 	@DisplayName("비밀번호 변경 실패: 현재 비밀번호 불일치")
 	public void testUpdatePassword_CurrentPasswordMismatch() {
 		// Given
-		UserRequest.UpdatePassword request = new UserRequest.UpdatePassword();
-		request.setCurrentPassword("wrongPass");
-		request.setNewPassword("newPass");
-		request.setNewPasswordConfirm("newPass");
+		UserRequest.UpdatePassword request = UserRequest.UpdatePassword.builder()
+			.currentPassword("wrongPass")
+			.newPassword("newPass")
+			.newPasswordConfirm("newPass")
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 		when(passwordEncoder.matches("wrongPass", dummyUser.getPassword())).thenReturn(false);
@@ -234,10 +240,11 @@ public class UserServiceTest {
 	@DisplayName("비밀번호 변경 실패: 새 비밀번호와 확인 비밀번호 불일치")
 	public void testUpdatePassword_ConfirmationMismatch() {
 		// Given
-		UserRequest.UpdatePassword request = new UserRequest.UpdatePassword();
-		request.setCurrentPassword("currentPass");
-		request.setNewPassword("newPass");
-		request.setNewPasswordConfirm("differentPass");
+		UserRequest.UpdatePassword request = UserRequest.UpdatePassword.builder()
+			.currentPassword("currentPass")
+			.newPassword("newPass")
+			.newPasswordConfirm("differentPass")
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 		when(passwordEncoder.matches("currentPass", dummyUser.getPassword())).thenReturn(true);
@@ -250,8 +257,9 @@ public class UserServiceTest {
 	@DisplayName("회원 탈퇴 성공")
 	public void testDeleteSoftlyUser_Success() {
 		// Given
-		UserRequest.Delete deleteRequest = new UserRequest.Delete();
-		deleteRequest.setPassword("deletePass");
+		UserRequest.Delete deleteRequest = UserRequest.Delete.builder()
+			.password("deletePass")
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 		when(passwordEncoder.matches("deletePass", dummyUser.getPassword())).thenReturn(true);
@@ -270,8 +278,9 @@ public class UserServiceTest {
 	@DisplayName("회원 탈퇴 실패: 비밀번호 불일치")
 	public void testDeleteSoftlyUser_PasswordMismatch() {
 		// Given
-		UserRequest.Delete deleteRequest = new UserRequest.Delete();
-		deleteRequest.setPassword("wrongPass");
+		UserRequest.Delete deleteRequest = UserRequest.Delete.builder()
+			.password("wrongPass")
+			.build();
 
 		when(userRepository.findById(dummyUserId)).thenReturn(Optional.of(dummyUser));
 		when(passwordEncoder.matches("wrongPass", dummyUser.getPassword())).thenReturn(false);

--- a/src/test/java/com/order/orderlink/user/application/UserServiceTest.java
+++ b/src/test/java/com/order/orderlink/user/application/UserServiceTest.java
@@ -24,12 +24,12 @@ import org.springframework.data.domain.Sort;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.util.ReflectionTestUtils;
 
-import com.order.orderlink.user.exception.UserException;
 import com.order.orderlink.user.application.dtos.UserRequest;
 import com.order.orderlink.user.application.dtos.UserResponse;
 import com.order.orderlink.user.domain.User;
 import com.order.orderlink.user.domain.UserRoleEnum;
 import com.order.orderlink.user.domain.repository.UserRepository;
+import com.order.orderlink.user.exception.UserException;
 
 @ExtendWith(MockitoExtension.class)
 public class UserServiceTest {
@@ -248,7 +248,7 @@ public class UserServiceTest {
 
 	@Test
 	@DisplayName("회원 탈퇴 성공")
-	public void testSoftDeleteUser_Success() {
+	public void testDeleteSoftlyUser_Success() {
 		// Given
 		UserRequest.Delete deleteRequest = new UserRequest.Delete();
 		deleteRequest.setPassword("deletePass");
@@ -268,7 +268,7 @@ public class UserServiceTest {
 
 	@Test
 	@DisplayName("회원 탈퇴 실패: 비밀번호 불일치")
-	public void testSoftDeleteUser_PasswordMismatch() {
+	public void testDeleteSoftlyUser_PasswordMismatch() {
 		// Given
 		UserRequest.Delete deleteRequest = new UserRequest.Delete();
 		deleteRequest.setPassword("wrongPass");


### PR DESCRIPTION
## Address
- Request와 Response에 private constructor 추가
- builder를 사용해 초기화 하도록 변경
- softDelete를 deleteSoftly로 변경
- Pageable 생성하는 코드의 인지복잡도를 줄이기 위해 메서드 분리

---

## Ai
- Request와 Response 생성자의 접근제어자를 private으로 변경
- generateDescription 메서드 내부에서 각 로직의 책임을 분리

---

## Review
- Request와 Response 생성자의 접근제어자를 private으로 변경
- softDelete 메서드를 deleteSoftly로 변경
- getReviewsByRestaurant 메서드의 인지복잡도를 줄이기 위해 메서드 분리

---

## User
- Request와 Response 생성자의 접근제어자를 private으로 변경
- builder를 사용해 초기화 하도록 변경
- softDelete를 deleteSoftly로 변경
- getAllUsers() 메서드의 인지복잡도를 줄이기 위해 내부에서 각 로직의 책임을 분리
- test 코드 수정

---

## Common
- TokenResponse의 필드명을 camel case로 변경

---